### PR TITLE
Updated to 0.2.0 and 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pleco"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -167,13 +167,13 @@ dependencies = [
 
 [[package]]
 name = "pleco_engine"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pleco 0.1.8",
+ "pleco 0.2.0",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Pleco
 
-Pleco is a chess Engine inspired by Stockfish, written entirely in Rust.
-
-This project aims to utilize the efficiency of Rust to create a Chess Bot with the speed of modern chess engines.
-
+Pleco is a chess Engine & Library inspired by Stockfish, written entirely in Rust.
 
 [![Pleco crate](https://img.shields.io/crates/v/pleco.svg)](https://crates.io/crates/pleco)
+[![Pleco crate](https://img.shields.io/crates/v/pleco_engine.svg)](https://crates.io/crates/pleco_engine)
 [![Build Status](https://api.travis-ci.org/sfleischman105/Pleco.svg?branch=master)](https://travis-ci.org/sfleischman105/Pleco)
 [![Build Status](https://api.travis-ci.org/sfleischman105/Pleco.svg?branch=Beta-Branch)](https://travis-ci.org/sfleischman105/Pleco)
 [![Coverage Status](https://coveralls.io/repos/github/sfleischman105/Pleco/badge.svg?branch=master)](https://coveralls.io/github/sfleischman105/Pleco?branch=master)
 
-- [Documentation](https://docs.rs/pleco)
-- [crates.io](https://crates.io/crates/pleco)
+
+This project is split into two crates, `pleco`, which contains the library functionality, and `pleco_engine`, which contains the
+UCI (Universal Chess Interface) compatible Engine & AI. 
+
+The overall goal for this project is to utilize the efficiency of Rust to create a Chess AI matching the speed of modern chess engines.
+
+- [Documentation](https://docs.rs/pleco), [crates.io](https://crates.io/crates/pleco) for library functionality
+- [Documentation](https://docs.rs/pleco_engine), [crates.io](https://crates.io/crates/pleco_engine) for UCI Engine and Advanced Searching functionality.
 
 Planned & Implemented features
 -------
@@ -23,11 +27,7 @@ The Library aims to have the following features upon completion
 - [x] Full Move-generation Capabilities
 - [x] Statically computed information (including Magic-Bitboards)
 - [x] Zobrist Hashing
-- [ ] UCI protocol implementation
-- [ ] Allowing matches against Human Players
 - [ ] PGN Parsing
-
-
 
 The AI Bot aims to have the following features:
 - [x] Alpha-Beta pruning
@@ -44,22 +44,7 @@ The AI Bot aims to have the following features:
 Standalone Installation and Use
 -------
 
-Currently, Pleco's use as a standalone program is limited in functionality. A UCI client is needed to properly interact with the program. As a recommendation, check out [Arena](http://www.playwitharena.com/).
-
-Firstly, clone the repo and navigate into the created folder with the following commands:
-
-```
-$ git clone https://github.com/sfleischman105/Pleco --branch master
-$ cd Pleco/
-```
-Once inside the pleco directory, build the binaries using `cargo`:
-```
-$ cargo build --release
-```
-
-The compiled program will appear in `./target/release/`.
-
-Pleco can now be run with a `./Pleco` on Linux or a `./Pleco.exe` on Windows.
+To use pleco as an executable, please [navigate to here](https://github.com/sfleischman105/Pleco/tree/master/pleco_engine) and read the `README.md`. 
 
 
 Using Pleco as a Library
@@ -69,7 +54,7 @@ To use Pleco inside your own Rust projects, [Pleco.rs is available as a library 
 
 ```
 [dependencies]
-pleco = "0.1.8"
+pleco = "0.2.0"
 ```
 
 And add the following to a `main.rs` or `lib.rs`:
@@ -130,8 +115,8 @@ board.undo_move();
 assert_eq!(board.moves_played(),0);
 ```
 
+For more informaton about `pleco` as a library, see the [pleco README.md](https://github.com/sfleischman105/Pleco/tree/master/pleco).
 
-  
 Contributing
 -------
 

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pleco"
 # REMINDER TO CHANGE IN README
-version = "0.1.8"
+version = "0.2.0"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess engine and Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/README.md
+++ b/pleco/README.md
@@ -1,14 +1,19 @@
 # Pleco
 
-Pleco is a chess Engine inspired by Stockfish, written entirely in Rust.
+Pleco is a Chess Library inspired by Stockfish, written entirely in Rust.
 
-This project aims to utilize the efficiency of Rust to create a Chess Bot with the speed of modern chess engines.
+This project aims to utilize the efficiency of Rust to create a Chess Library & AI with the speed of modern chess engines. 
 
 
 [![Pleco crate](https://img.shields.io/crates/v/pleco.svg)](https://crates.io/crates/pleco)
 [![Build Status](https://api.travis-ci.org/sfleischman105/Pleco.svg?branch=master)](https://travis-ci.org/sfleischman105/Pleco)
 [![Build Status](https://api.travis-ci.org/sfleischman105/Pleco.svg?branch=Beta-Branch)](https://travis-ci.org/sfleischman105/Pleco)
 [![Coverage Status](https://coveralls.io/repos/github/sfleischman105/Pleco/badge.svg?branch=master)](https://coveralls.io/github/sfleischman105/Pleco?branch=master)
+
+This project is split into two crates, `pleco` (the library you are currently in), which contains the library functionality, and `pleco_engine`, which contains the
+UCI (Universal Chess Interface) compatible Engine & AI. 
+
+The overall goal for this project is to utilize the efficiency of Rust to create a Chess AI matching the speed of modern chess engines.
 
 - [Documentation](https://docs.rs/pleco)
 - [crates.io](https://crates.io/crates/pleco)
@@ -23,53 +28,18 @@ The Library aims to have the following features upon completion
 - [x] Full Move-generation Capabilities
 - [x] Statically computed information (including Magic-Bitboards)
 - [x] Zobrist Hashing
-- [ ] UCI protocol implementation
 - [ ] Allowing matches against Human Players
 - [ ] PGN Parsing
 
 
-
-The AI Bot aims to have the following features:
-- [x] Alpha-Beta pruning
-- [x] Multi-threaded search with rayon.rs
-- [x] Queiscience-search
-- [x] MVV-LVA sorting
-- [x] Iterative Deepening
-- [x] Aspiration Windows
-- [x] Futility Pruning
-- [x] Transposition Tables
-- [ ] Null Move Heuristic
-- [ ] Killer Moves
-
-Standalone Installation and Use
--------
-
-Currently, Pleco's use as a standalone program is limited in functionality. A UCI client is needed to properly interact with the program. As a recommendation, check out [Arena](http://www.playwitharena.com/).
-
-Firstly, clone the repo and navigate into the created folder with the following commands:
-
-```
-$ git clone https://github.com/sfleischman105/Pleco --branch master
-$ cd Pleco/
-```
-Once inside the pleco directory, build the binaries using `cargo`:
-```
-$ cargo build --release
-```
-
-The compiled program will appear in `./target/release/`.
-
-Pleco can now be run with a `./Pleco` on Linux or a `./Pleco.exe` on Windows.
-
-
-Using Pleco as a Library
+Use
 -------
 
 To use Pleco inside your own Rust projects, [Pleco.rs is available as a library on crates.io.](https://crates.io/crates/pleco) Simply include the following in your Cargo.toml:
 
 ```
 [dependencies]
-pleco = "0.1.8"
+pleco = "0.2.0"
 ```
 
 And add the following to a `main.rs` or `lib.rs`:
@@ -130,13 +100,11 @@ board.undo_move();
 assert_eq!(board.moves_played(),0);
 ```
 
-
   
 Contributing
 -------
 
 Any and all contributions are welcome! Open up a PR to contribute some improvements. Look at the Issues tab to see what needs some help. 
-
 
   
 License

--- a/pleco/src/engine.rs
+++ b/pleco/src/engine.rs
@@ -1,4 +1,4 @@
-//! This module contains an engine for actually playing chess.
+//! This module contains functions and traits useful for actually playing a game of chess.
 
 extern crate rand;
 
@@ -9,7 +9,7 @@ use core::Player;
 
 // TODO: clean this up
 
-/// Trait that defines an object that can play chess
+/// Trait that defines an object that can play chess.
 pub trait Searcher {
     fn name() -> &'static str where Self: Sized;
 

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -1,7 +1,7 @@
-//! A blazingly fast Chess Engine and Chess AI.
+//! A blazingly fast Chess Library.
 //!
-//! This package is seperated into two parts. Firstly, the board representation & associated functions. and Secondly,
-//! the AI implementations.
+//! This package is seperated into two parts. Firstly, the board representation & associated functions (the current crate, `pleco`), And Secondly,
+//! the AI implementations (`pleco_engine`).
 //!
 //! # Usage
 //!

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -235,6 +235,12 @@ impl TT {
     /// # Panic
     ///
     /// size must be greater then 0
+    ///
+    /// # Safety
+    ///
+    /// This is function is unsafe to use if the TT is currently being accessed, Or any thread of
+    /// structure contains a current reference to a `TTEntry`. Otherwise, using this function will
+    /// absolutely lead to Segmentation Fault.
     pub unsafe fn resize_round_up(&self, size: usize) {
         self.resize(size.next_power_of_two());
     }
@@ -245,6 +251,12 @@ impl TT {
     /// # Panic
     ///
     /// mb_size must be greater then 0
+    ///
+    /// # Safety
+    ///
+    /// This is function is unsafe to use if the TT is currently being accessed, Or any thread of
+    /// structure contains a current reference to a `TTEntry`. Otherwise, using this function will
+    /// absolutely lead to Segmentation Fault.
     pub unsafe fn resize_to_megabytes(&self, mb_size: usize) -> usize {
         assert!(mb_size > 0);
         let mut num_clusters: usize = (mb_size * BYTES_PER_MB) / mem::size_of::<Cluster>();
@@ -263,6 +275,12 @@ impl TT {
     }
 
     /// Clears the entire TranspositionTable
+    ///
+    /// # Safety
+    ///
+    /// This is function is unsafe to use if the TT is currently being accessed, Or any thread of
+    /// structure contains a current reference to a `TTEntry`. Otherwise, using this function will
+    /// absolutely lead to Segmentation Fault.
     pub unsafe fn clear(&self) {
         let size = self.cap.get();
         self.resize(*size);

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pleco_engine"
 # REMINDER TO CHANGE IN README
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"
@@ -71,7 +71,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.1.8" }
+pleco = { path = "../pleco", version = "0.2.0" }
 clippy = {version = "0.0.169", optional = true}
 lazy_static = "0.2"
 bitflags = "1.0"

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -1,12 +1,15 @@
 //! A blazingly fast Chess Engine and Chess AI.
 //!
-//! This package is seperated into two parts. Firstly, the board representation & associated functions. and Secondly,
-//! the AI implementations.
+//! This crate is not intended to be used by other crates as a dependency, as it's a mostly useful as a direct
+//! executable.
 //!
-//! # Usage
+//! If you are interested in using the direct chess library functions (The Boards, move generation, etc), please
+//! checkout the core library, `pleco`, available on [on crates.io](https://crates.io/crates/pleco).
 //!
-//! This crate is [on crates.io](https://crates.io/crates/pleco) and can be
-//! used by adding `pleco` to the dependencies in your project's `Cargo.toml`.
+//! # Usage as a Dependency
+//!
+//! This crate is [on crates.io](https://crates.io/crates/pleco_engine) and can be
+//! used by adding `pleco_engine` to the dependencies in your project's `Cargo.toml`.
 //!
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]


### PR DESCRIPTION
Updated `pleco` to 0.2.0 and `pleco_engine` to 0.0.2.

With this, clarified all three README's a little more as well as added some better documentation for each library.