### PR TITLE
Bug fixes inside `sq::SQ`, update to 0.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use Pleco inside your own Rust projects, [Pleco.rs is available as a library 
 
 ```
 [dependencies]
-pleco = "0.3.5"
+pleco = "0.3.6"
 ```
 
 And add the following to a `main.rs` or `lib.rs`:

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pleco"
 # REMINDER TO CHANGE IN MAIN README
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -2041,7 +2041,7 @@ impl Board {
 
 // TODO: Error Propagation
 
-/// Represents possible Errors encountered while building a `Board` from a fen string.
+/// Errors concerning the current `Board` position.
 pub enum BoardError {
     IncorrectKingNum {player: Player, num: u8},
 }

--- a/pleco/src/core/bitboard.rs
+++ b/pleco/src/core/bitboard.rs
@@ -78,7 +78,10 @@ impl BitBoard {
     /// BitBoard of Rank 8.
     pub const RANK_8: BitBoard = BitBoard(RANK_8);
 
-    pub const DARK_SQUARES: BitBoard = BitBoard(0xAA55AA55AA55AA55);
+    /// BitBoard of all dark squares.
+    pub const DARK_SQUARES: BitBoard = BitBoard(DARK_SQUARES);
+    /// BitBoard of all light squares.
+    pub const LIGHT_SQUARES: BitBoard = BitBoard(LIGHT_SQUARES);
 
     /// Converts a `BitBoard` to a square.
     ///

--- a/pleco/src/core/masks.rs
+++ b/pleco/src/core/masks.rs
@@ -67,6 +67,10 @@ pub const RANK_7: u64 = 0x00FF_0000_0000_0000;
 /// Bit representation of rank 8.
 pub const RANK_8: u64 = 0xFF00_0000_0000_0000;
 
+/// Bit representation of rank dark squares.
+pub const DARK_SQUARES: u64 = 0xAA55AA55AA55AA55;
+/// Bit representation of all light squares.
+pub const LIGHT_SQUARES: u64 = !DARK_SQUARES;
 
 /// Array of all files and their corresponding bits, indexed from
 /// file A to file H.

--- a/pleco/src/core/sq.rs
+++ b/pleco/src/core/sq.rs
@@ -98,7 +98,7 @@ impl SQ {
     /// assert!(!no_sq.is_okay());
     /// ```
     #[inline(always)]
-    pub fn is_okay(self) -> bool {
+    pub const fn is_okay(self) -> bool {
         self.0 < 64
     }
 
@@ -164,7 +164,7 @@ impl SQ {
 
     /// Returns the rank index (number) of a `SQ`.
     #[inline(always)]
-    pub fn rank_idx_of_sq(self) -> u8 {
+    pub const fn rank_idx_of_sq(self) -> u8 {
         (self.0 >> 3) as u8
     }
 
@@ -233,20 +233,20 @@ impl SQ {
     #[inline(always)]
     /// Returns if the `SQ` is a dark square.
     pub fn on_dark_square(self) -> bool {
-        self.0 % 2 == 0
+        (self.to_bb() & BitBoard::DARK_SQUARES).is_empty()
     }
 
     /// Returns if the `SQ` is a dark square.
     #[inline(always)]
     pub fn on_light_square(self) -> bool {
-        self.0 % 2 == 1
+        (self.to_bb() & BitBoard::DARK_SQUARES).is_not_empty()
     }
 
     // 0 = white squares, 1 = black square
     /// Returns the player index of the color of the square.
     #[inline(always)]
     pub fn square_color_index(self) -> usize {
-        ((self.0 + 1) % 2) as usize
+        self.on_dark_square() as usize
     }
 
     /// Flips the square, so `SQ::A1` -> `SQ::A8`.

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -67,7 +67,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.3.5" }
+pleco = { path = "../pleco", version = "0.3.6" }
 clippy = {version = "0.0.179", optional = true}
 chrono = "0.4.0"
 rand = "0.4.2"


### PR DESCRIPTION
Updated `pleco` to 0.3.6.

Also fixed a bug in `SQ`, where the color of the square wasn't being calculate properly.