### PR TITLE
Quiescence search, version updates & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Library aims to have the following features upon completion
 The AI Bot aims to have the following features:
 - [x] Alpha-Beta pruning
 - [x] Multi-threaded search with rayon.rs
-- [ ] Queiscience-search
+- [x] Queiscience-search
 - [x] MVV-LVA sorting
 - [x] Iterative Deepening
 - [x] Aspiration Windows

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pleco"
 # REMINDER TO CHANGE IN MAIN README
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/benches/board_benches.rs
+++ b/pleco/benches/board_benches.rs
@@ -17,7 +17,7 @@ lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         let mut prng = PRNG::init(SEED);
         let mut boards = RAND_BOARD_FENS.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>();
 
         boards.iter_mut().for_each(|b| {

--- a/pleco/benches/eval_benches.rs
+++ b/pleco/benches/eval_benches.rs
@@ -13,7 +13,7 @@ use test::{black_box, Bencher};
 lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         RAND_BOARD_NON_CHECKS_100.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 }

--- a/pleco/benches/move_gen_benches.rs
+++ b/pleco/benches/move_gen_benches.rs
@@ -14,19 +14,19 @@ use test::{black_box, Bencher};
 lazy_static! {
     pub static ref RAND_BOARDS_ANY: Vec<Board> = {
         RAND_BOARD_ANY_GEN.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 
     pub static ref RAND_BOARDS_CHECKS: Vec<Board> = {
         RAND_BOARD_IN_CHECKS_GEN.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 
     pub static ref RAND_BOARDS_NON_CHECKS: Vec<Board> = {
         RAND_BOARD_NON_CHECKS_GEN.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 }

--- a/pleco/benches/perft_benches.rs
+++ b/pleco/benches/perft_benches.rs
@@ -14,7 +14,7 @@ use test::{black_box, Bencher};
 lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         RAND_BOARDS_ALL.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 }

--- a/pleco/benches/tt_benches.rs
+++ b/pleco/benches/tt_benches.rs
@@ -34,7 +34,7 @@ fn tt_bench_single_thread_insert_full(b: &mut Bencher) {
     b.iter(|| {
         let key = prng.rand();
         let (_found, entry) = tt.probe(key);
-        entry.place(key, BitMove::new(0x555), 3, 4, key as i8, NodeBound::Exact, tt.time_age());
+        entry.place(key, BitMove::new(0x555), 3, 4, key as i16, NodeBound::Exact, tt.time_age());
     })
 }
 

--- a/pleco/benches/tt_benches.rs
+++ b/pleco/benches/tt_benches.rs
@@ -15,7 +15,7 @@ fn tt_bench_single_thread_insert_empty(b: &mut Bencher) {
     b.iter(|| {
         let key = prng.rand();
         let (_found, entry) = tt.probe(key);
-        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact);
+        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact, tt.time_age());
     })
 }
 
@@ -27,14 +27,14 @@ fn tt_bench_single_thread_insert_full(b: &mut Bencher) {
     for x in 0..1_600_000 {
         let key = prng.rand();
         let (_found, entry) = tt.probe(key);
-        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact);
-        entry.depth = x as u8;
+        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact, tt.time_age());
+        entry.depth = x as i8;
     }
 
     b.iter(|| {
         let key = prng.rand();
         let (_found, entry) = tt.probe(key);
-        entry.place(key, BitMove::new(0x555), 3, 4, key as u8, NodeBound::Exact);
+        entry.place(key, BitMove::new(0x555), 3, 4, key as i8, NodeBound::Exact, tt.time_age());
     })
 }
 
@@ -59,8 +59,8 @@ fn tt_single_thread_lookup(b: &mut Bencher, num_entries: usize, placements: u64,
     for x in 0..placements {
         let key = prng.rand();
         let (_found, entry) = tt.probe(key);
-        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact);
-        entry.depth = x as u8;
+        entry.place(key, BitMove::new(0x555), 3, 4, 3, NodeBound::Exact, tt.time_age());
+        entry.depth = x as i8;
     }
 
     b.iter(|| {

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -152,6 +152,7 @@ impl BoardState {
     }
 
     /// Return the previous BoardState from one move ago.
+    #[inline]
     pub fn get_prev(&self) -> Option<Arc<BoardState>> {
         (&self).prev.as_ref().cloned()
     }

--- a/pleco/src/board/fen.rs
+++ b/pleco/src/board/fen.rs
@@ -178,6 +178,6 @@ mod tests {
 
     #[test]
     fn fen_extra_pawns(){
-        assert!(Board::new_from_fen(EXTRA_PAWNS).is_err());
+        assert!(Board::from_fen(EXTRA_PAWNS).is_err());
     }
 }

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -516,12 +516,12 @@ impl Board {
         if ep_sq == SQ(0) {ep_sq = NO_SQ}
 
         // rule 50 counts
-        let rule_50 = if det_split.len() >= 5 { det_split[4].parse::<i16>()?} else {0};
+        let rule_50 = if det_split.len() >= 5 && det_split[4] != "-" { det_split[4].parse::<i16>()?} else {0};
 
 
         // Total Moves Played
         // Moves is defined as everyime White moves, so gotta translate to total moves
-        let mut total_moves = if det_split.len() >= 6 {(det_split[5].parse::<u16>()? - 1) * 2} else {0};
+        let mut total_moves = if det_split.len() >= 6 && det_split[5] != "-" {(det_split[5].parse::<u16>()? - 1) * 2} else {0};
         if turn == Player::Black {
             total_moves += 1
         };

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -445,14 +445,14 @@ impl Board {
     /// There is a possibility of the FEN string representing an unvalid position, with no panics resulting.
     /// The Constructed Board may have some Undefined Behavior as a result. It is up to the user to give a
     /// valid FEN string.
-    pub fn new_from_fen(fen: &str) -> Result<Board,FenBuildError> {
+    pub fn from_fen(fen: &str) -> Result<Board,FenBuildError> {
 
         // split the string by white space
         let det_split: Vec<&str> = fen.split_whitespace().collect();
 
         // must have 6 parts :
         // [ Piece Placement, Side to Move, Castling Ability, En Passant square, Half moves, full moves]
-        if det_split.len() != 6 {
+        if det_split.len() < 4 || det_split.len() > 6{
             return Err(FenBuildError::NotEnoughSections{sections: det_split.len()});
         }
 
@@ -516,11 +516,12 @@ impl Board {
         if ep_sq == SQ(0) {ep_sq = NO_SQ}
 
         // rule 50 counts
-        let rule_50 = det_split[4].parse::<i16>()?;
+        let rule_50 = if det_split.len() >= 5 { det_split[4].parse::<i16>()?} else {0};
+
 
         // Total Moves Played
         // Moves is defined as everyime White moves, so gotta translate to total moves
-        let mut total_moves = (det_split[5].parse::<u16>()? - 1) * 2;
+        let mut total_moves = if det_split.len() >= 6 {(det_split[5].parse::<u16>()? - 1) * 2} else {0};
         if turn == Player::Black {
             total_moves += 1
         };
@@ -585,7 +586,7 @@ impl Board {
     /// let board = Board::default();
     /// assert_eq!(board.get_fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     /// ```
-    pub fn get_fen(&self) -> String {
+    pub fn fen(&self) -> String {
         let mut s = String::default();
         let mut blanks = 0;
         for idx in 0..SQ_CNT as u8 {
@@ -1788,7 +1789,6 @@ impl Board {
     /// if suddenly removed, the player would find itself in check.
     #[inline(always)]
     pub fn pieces_pinned(&self, player: Player) -> BitBoard {
-        // TODO: combine with Board::piece_pinned
         self.state.blockers_king[player as usize] & self.get_occupied_player(player)
     }
     /// Returns a BitBoard of possible attacks / defends to a square with a given occupancy.
@@ -1893,7 +1893,7 @@ impl Board {
         assert_eq!(self.color_of_sq(src).unwrap(), self.turn);
 
         // Searches for direct checks from the pre-computed array
-        if (self.state.check_sqs[self.piece_at_sq(src).unwrap() as usize] & dst_bb).is_not_empty() {
+        if (self.state.check_sqs[self.piece_at_sq(src).unwrap() as usize] & dst_bb).is_not_empty()  {
             return true;
         }
 
@@ -1942,12 +1942,8 @@ impl Board {
                 let r_to: SQ = self.turn.relative_square( { if r_from > k_from { SQ(5) } else { SQ(3) } });
 
                 let opp_k_bb = opp_king_sq.to_bb();
-                (rook_moves(BitBoard(0), r_to) & opp_k_bb).is_not_empty() &&
-                    (rook_moves(
-                        r_to.to_bb() | k_to.to_bb() |
-                            (self.get_occupied() ^ k_from.to_bb() ^ r_from.to_bb()),
-                        r_to,
-                    ) & opp_k_bb).is_not_empty()
+                (rook_moves(BitBoard(0), r_to) & opp_k_bb).is_not_empty()
+                    && (rook_moves(r_to.to_bb() | k_to.to_bb() | (self.get_occupied() ^ k_from.to_bb() ^ r_from.to_bb()), r_to, ) & opp_k_bb).is_not_empty()
             }
         }
     }
@@ -2344,7 +2340,7 @@ mod tests {
         let mut ply = 1000;
         let mut fen_stack = Vec::new();
         while ply > 0 && !board.checkmate() && !board.stalemate() {
-            fen_stack.push(board.get_fen());
+            fen_stack.push(board.fen());
             let moves = board.generate_moves();
             let picked_move = moves[rand::random::<usize>() % moves.len()];
             board.apply_move(picked_move);
@@ -2353,7 +2349,7 @@ mod tests {
 
         while !fen_stack.is_empty() {
             board.undo_move();
-            assert_eq!(board.get_fen(),fen_stack.pop().unwrap());
+            assert_eq!(board.fen(), fen_stack.pop().unwrap());
         }
     }
 

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -434,7 +434,7 @@ impl Board {
     /// ```
     /// use pleco::Board;
     ///
-    /// let board = Board::new_from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+    /// let board = Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
     /// assert_eq!(board.count_all_pieces(),32);
     /// ```
     ///
@@ -584,7 +584,7 @@ impl Board {
     /// use pleco::Board;
     ///
     /// let board = Board::default();
-    /// assert_eq!(board.get_fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    /// assert_eq!(board.fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     /// ```
     pub fn fen(&self) -> String {
         let mut s = String::default();
@@ -1036,7 +1036,7 @@ impl Board {
     /// unsafe { chessboard.undo_null_move(); }
     ///
     /// assert_eq!(chessboard.moves_played(), board_clone.moves_played());
-    /// assert_eq!(chessboard.get_fen(), board_clone.get_fen());
+    /// assert_eq!(chessboard.fen(), board_clone.fen());
     /// ```
     pub unsafe fn undo_null_move(&mut self) {
         assert!(self.state.prev_move.is_null());

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn movegen_list_sim_all() {
         let boards: Vec<Board> = ALL_FENS.iter()
-            .map(|f| Board::new_from_fen(*f).unwrap())
+            .map(|f| Board::from_fen(*f).unwrap())
             .collect();
 
         boards.iter().for_each(|b| {

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -97,6 +97,19 @@ fn inner_perft_all(board: &mut Board, depth: u16, perft: &mut PerftNodes) {
 mod tests {
     use super::*;
 
+    fn check_perft(perft: PerftNodes,
+                   nodes: u64,      captures: u64, en_passant: u64,
+                   promotions: u64, checks: u64,   checkmates: u64, castles: u64) {
+
+        assert_eq!(perft.captures, captures);
+        assert_eq!(perft.en_passant, en_passant);
+        assert_eq!(perft.promotions, promotions);
+        assert_eq!(perft.checks, checks);
+        assert_eq!(perft.checkmates, checkmates);
+        assert_eq!(perft.castles, castles);
+        assert_eq!(perft.nodes, nodes);
+    }
+
     #[test]
     fn start_pos_perft() {
         let b: Board = Board::default();
@@ -112,23 +125,11 @@ mod tests {
     fn start_pos_perft_all() {
         let b: Board = Board::default();
         check_perft(perft_all(&b,3),
-                    8902, 34, 0, 0, 12, 0);
+                    8902, 34, 0, 0, 12, 0, 0);
         check_perft(perft_all(&b,4),
-                    197_281, 1576, 0, 0, 469, 8);
+                    197_281, 1576, 0, 0, 469, 8, 0);
         check_perft(perft_all(&b,5),
-                    4_865_609, 82_719, 258, 0, 27351, 347);
-    }
-
-    fn check_perft(perft: PerftNodes,
-                   nodes: u64,      captures: u64, en_passant: u64,
-                   promotions: u64, checks: u64,   checkmates: u64) {
-
-        assert_eq!(perft.nodes, nodes);
-        assert_eq!(perft.captures, captures);
-        assert_eq!(perft.en_passant, en_passant);
-        assert_eq!(perft.promotions, promotions);
-        assert_eq!(perft.checks, checks);
-        assert_eq!(perft.checkmates, checkmates);
+                    4_865_609, 82_719, 258, 0, 27351, 347, 0);
     }
 
     #[test]
@@ -139,5 +140,46 @@ mod tests {
         assert_eq!(97862, perft(&b,3));
         assert_eq!(4085603, perft(&b,4));
         assert_eq!(193690690, perft(&b,5));
+    }
+
+    #[ignore]
+    #[test]
+    fn perft_kiwipete_all() {
+        let b: Board = Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -").unwrap();
+        check_perft(perft_all(&b,3),
+                    97862, 17102, 45, 0, 993, 1, 3162);
+        check_perft(perft_all(&b,4),
+                    4085603, 757163, 1929, 15172, 25523, 43, 128013);
+        check_perft(perft_all(&b,5),
+                    193690690, 35043416, 73365, 8392, 3309887, 30171, 4993637);
+    }
+
+    #[test]
+    fn perft_board_3() {
+        let b: Board = Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -").unwrap();
+        assert_eq!(14, perft(&b,1));
+        assert_eq!(191, perft(&b,2));
+        assert_eq!(2812, perft(&b,3));
+        assert_eq!(43238, perft(&b,4));
+        assert_eq!(674624, perft(&b,5));
+    }
+
+    #[test]
+    fn perft_board_5() {
+        let b: Board = Board::from_fen("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8 ").unwrap();
+        assert_eq!(44, perft(&b,1));
+        assert_eq!(1_486, perft(&b,2));
+        assert_eq!(62_379, perft(&b,3));
+        assert_eq!(2_103_487, perft(&b,4));
+        assert_eq!(89_941_194, perft(&b,5));
+    }
+
+    #[test]
+    fn perft_board_6() {
+        let b: Board = Board::from_fen("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10").unwrap();
+        assert_eq!(46, perft(&b,1));
+        assert_eq!(2_079, perft(&b,2));
+        assert_eq!(89_890, perft(&b,3));
+        assert_eq!(3_894_594, perft(&b,4));
     }
 }

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -130,4 +130,14 @@ mod tests {
         assert_eq!(perft.checks, checks);
         assert_eq!(perft.checkmates, checkmates);
     }
+
+    #[test]
+    fn perft_kiwipete() {
+        let b: Board = Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -").unwrap();
+        assert_eq!(48, perft(&b,1));
+        assert_eq!(2039, perft(&b,2));
+        assert_eq!(97862, perft(&b,3));
+        assert_eq!(4085603, perft(&b,4));
+        assert_eq!(193690690, perft(&b,5));
+    }
 }

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -132,6 +132,7 @@ mod tests {
                     4_865_609, 82_719, 258, 0, 27351, 347, 0);
     }
 
+    #[ignore]
     #[test]
     fn perft_kiwipete() {
         let b: Board = Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -").unwrap();

--- a/pleco/src/core/bit_twiddles.rs
+++ b/pleco/src/core/bit_twiddles.rs
@@ -146,7 +146,7 @@ pub fn lsb(bits: u64) -> u64 {
 }
 
 /// Counts the number of bits in a u64.
-#[inline(always)]
+#[inline]
 pub fn popcount_old(x: u64) -> u8 {
     let x = x as usize;
     if x == 0 {

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -131,9 +131,14 @@ impl Player {
     /// assert_eq!(b.relative_rank(Rank::R8), Rank::R1);
     /// assert_eq!(b.relative_rank(Rank::R1), Rank::R8);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn relative_rank(&self, rank: Rank) -> Rank {
-        ALL_RANKS[((rank as u8) ^ (*self as u8 * 7)) as usize]
+        let r = (rank as u8) ^ (*self as u8 * 7);
+        debug_assert!(r < 8);
+//        ALL_RANKS[((rank as u8) ^ (*self as u8 * 7)) as usize]
+        unsafe {
+            mem::transmute::<u8,Rank>(r)
+        }
     }
 }
 
@@ -267,14 +272,14 @@ pub enum File {
 impl File {
 
     /// Returns the bit-set of all files to the left of the current file.
-    #[inline(always)]
-    pub fn left_side_mask(self) -> u8 {
+    #[inline]
+    pub const fn left_side_mask(self) -> u8 {
         (1 << self as u8) - 1
     }
 
     /// Returns the bit-set of all files to the right of the current file.
-    #[inline(always)]
-    pub fn right_side_mask(self) -> u8 {
+    #[inline]
+    pub const fn right_side_mask(self) -> u8 {
         !((1 << (self as u16 + 1)) - 1) as u8
     }
 
@@ -290,6 +295,7 @@ impl File {
     ///
     /// assert_eq!(file_a.min(File::C), File::A);
     /// ```
+    #[inline]
     pub fn min(self, other: File) -> File {
         if (self as u8) < (other as u8) {
             self
@@ -309,6 +315,7 @@ impl File {
     ///
     /// assert_eq!(file_a.max(File::C), File::C);
     /// ```
+    #[inline]
     pub fn max(self, other: File) -> File {
         if (self as u8) > (other as u8) {
             self

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -66,12 +66,12 @@ use super::sq::SQ;
 use std::fmt;
 
 // Castles have the src as the king bit and the dst as the rook
-static SRC_MASK: u16 = 0b0000_000000_111111;
-static DST_MASK: u16 = 0b0000_111111_000000;
-static PR_MASK: u16 = 0b1000_000000_000000;
-static CP_MASK: u16 = 0b0100_000000_000000;
-static FLAG_MASK: u16 = 0b1111_000000_000000;
-static SP_MASK: u16 = 0b0011_000000_000000;
+const SRC_MASK: u16 = 0b0000_000000_111111;
+const DST_MASK: u16 = 0b0000_111111_000000;
+const PR_MASK: u16 = 0b1000_000000_000000;
+const CP_MASK: u16 = 0b0100_000000_000000;
+const FLAG_MASK: u16 = 0b1111_000000_000000;
+const SP_MASK: u16 = 0b0011_000000_000000;
 
 /// Represents a singular move. 
 ///
@@ -156,32 +156,32 @@ impl BitMove {
     /// Using this method cannot guarantee that the move is legal. The input bits must be encoding a legal
     /// move, or else there is Undefined Behavior if the resulting BitMove is used.
     #[inline]
-    pub fn new(input: u16) -> BitMove {
+    pub const fn new(input: u16) -> BitMove {
         BitMove { data: input }
     }
 
     /// Makes a quiet `BitMove` from a source and destination square.
     #[inline(always)]
-    pub fn make_quiet(src: SQ, dst: SQ) -> BitMove {
+    pub const fn make_quiet(src: SQ, dst: SQ) -> BitMove {
         BitMove::make(BitMove::FLAG_QUIET,src,dst)
     }
 
     /// Makes a pawn-push `BitMove` from a source and destination square.
     #[inline(always)]
-    pub fn make_pawn_push(src: SQ, dst: SQ) -> BitMove {
+    pub const fn make_pawn_push(src: SQ, dst: SQ) -> BitMove {
         BitMove::make(BitMove::FLAG_DOUBLE_PAWN,src,dst)
     }
 
     /// Makes a non-enpassant `BitMove` from a source and destination square.
     #[inline(always)]
-    pub fn make_capture(src: SQ, dst: SQ) -> BitMove {
+    pub const fn make_capture(src: SQ, dst: SQ) -> BitMove {
         BitMove::make(BitMove::FLAG_CAPTURE,src,dst)
     }
 
     /// Creates a `BitMove` from a source and destination square, as well as the current
     /// flag.
     #[inline]
-    pub fn make(flag_bits: u16, src: SQ, dst: SQ) -> BitMove {
+    pub const fn make(flag_bits: u16, src: SQ, dst: SQ) -> BitMove {
         BitMove { data: (flag_bits << 12) | src.0 as u16 | ((dst.0 as u16) << 6) }
     }
 
@@ -243,73 +243,73 @@ impl BitMove {
     ///
     /// See [BitMove::null()] for more information on Null moves.
     #[inline]
-    pub fn is_null(&self) -> bool {
+    pub const fn is_null(&self) -> bool {
         self.data == 0
     }
 
     /// Returns if a [BitMove] captures an opponent's piece.
     #[inline(always)]
-    pub fn is_capture(&self) -> bool {
+    pub const fn is_capture(&self) -> bool {
         ((self.data & CP_MASK) >> 14) == 1
     }
 
     /// Returns if a [BitMove] is a Quiet Move, meaning it is not any of the following: a capture, promotion, castle, or double pawn push.
     #[inline(always)]
-    pub fn is_quiet_move(&self) -> bool {
+    pub const fn is_quiet_move(&self) -> bool {
         ((self.data & FLAG_MASK) >> 12) == 0
     }
 
     /// Returns if a [BitMove] is a promotion.
     #[inline(always)]
-    pub fn is_promo(&self) -> bool {
+    pub const fn is_promo(&self) -> bool {
         (self.data & PR_MASK) != 0
     }
 
     /// Returns the destination of a [BitMove].
     #[inline(always)]
-    pub fn get_dest(&self) -> SQ {
+    pub const fn get_dest(&self) -> SQ {
         SQ(self.get_dest_u8())
     }
 
     /// Returns the destination of a [BitMove].
     #[inline(always)]
-    pub fn get_dest_u8(&self) -> u8 {
+    pub const fn get_dest_u8(&self) -> u8 {
         ((self.data & DST_MASK) >> 6) as u8
     }
 
     /// Returns the source square of a [BitMove].
     #[inline(always)]
-    pub fn get_src(&self) -> SQ {
+    pub const fn get_src(&self) -> SQ {
         SQ(self.get_src_u8())
     }
 
     /// Returns the source square of a [BitMove].
     #[inline(always)]
-    pub fn get_src_u8(&self) -> u8 {
+    pub const fn get_src_u8(&self) -> u8 {
         (self.data & SRC_MASK) as u8
     }
 
     /// Returns if a [BitMove] is a castle.
     #[inline(always)]
-    pub fn is_castle(&self) -> bool {
+    pub const fn is_castle(&self) -> bool {
         ((self.data & FLAG_MASK) >> 13) == 1
     }
 
     /// Returns if a [BitMove] is a Castle && it is a KingSide Castle.
     #[inline(always)]
-    pub fn is_king_castle(&self) -> bool {
+    pub const fn is_king_castle(&self) -> bool {
         ((self.data & FLAG_MASK) >> 12) == 2
     }
 
     /// Returns if a [BitMove] is a Castle && it is a QueenSide Castle.
     #[inline(always)]
-    pub fn is_queen_castle(&self) -> bool {
+    pub const fn is_queen_castle(&self) -> bool {
         ((self.data & FLAG_MASK) >> 12) == 3
     }
 
     /// Returns if a [BitMove] is an enpassant capture.
     #[inline(always)]
-    pub fn is_en_passant(&self) -> bool {
+    pub const fn is_en_passant(&self) -> bool {
         (self.data & FLAG_MASK) >> 12 == 5
     }
 
@@ -411,8 +411,8 @@ impl BitMove {
     }
 
     /// Returns the raw number representation of the move.
-    #[inline]
-    pub fn get_raw(&self) -> u16 {
+    #[inline(always)]
+    pub const fn get_raw(&self) -> u16 {
         self.data
     }
 }
@@ -426,6 +426,7 @@ pub struct ScoringBitMove {
 }
 
 impl Default for ScoringBitMove {
+    #[inline(always)]
     fn default() -> Self {
         ScoringBitMove {
             bit_move: BitMove::null(),
@@ -435,6 +436,7 @@ impl Default for ScoringBitMove {
 }
 
 impl ScoringBitMove {
+    #[inline(always)]
     pub fn new(m: BitMove) -> Self {
         ScoringBitMove {
             bit_move: m,
@@ -442,6 +444,7 @@ impl ScoringBitMove {
         }
     }
 
+    #[inline(always)]
     pub fn new_score(m: BitMove, score: i16) -> Self {
         ScoringBitMove {
             bit_move: m,
@@ -449,10 +452,12 @@ impl ScoringBitMove {
         }
     }
 
+    #[inline(always)]
     pub fn bitmove(&self) -> BitMove {
         self.bit_move
     }
 
+    #[inline(always)]
     pub fn score(&self) -> i16 {
         self.score
     }

--- a/pleco/src/core/sq.rs
+++ b/pleco/src/core/sq.rs
@@ -193,7 +193,7 @@ impl SQ {
 
     /// Returns the file index (number) of a `SQ`.
     #[inline(always)]
-    pub fn file_idx_of_sq(self) -> u8 {
+    pub const fn file_idx_of_sq(self) -> u8 {
         (self.0 & 0b0000_0111) as u8
     }
 

--- a/pleco/src/tools/prng.rs
+++ b/pleco/src/tools/prng.rs
@@ -32,7 +32,7 @@ impl PRNG {
 
     /// Returns a u64 with exactly one bit set in a random location.
     pub fn singular_bit(&mut self) -> u64 {
-        let num: u64 = 0;
+        let num: u64 = 1;
         num.wrapping_shl(self.rand().count_ones())
     }
 

--- a/pleco/tests/basic_bots.rs
+++ b/pleco/tests/basic_bots.rs
@@ -5,8 +5,6 @@ use pleco::tools::Searcher;
 use pleco::bot_prelude::*;
 use pleco::board::{Board,RandBoard};
 
-use pleco::tools::eval::Eval;
-
 
 #[test]
 fn test_all_bot() {

--- a/pleco/tests/fen_building.rs
+++ b/pleco/tests/fen_building.rs
@@ -44,6 +44,6 @@ fn basic_fen() {
 fn all_fens() {
     for fen in pleco::board::fen::ALL_FENS.iter() {
         let board = Board::from_fen(*fen).unwrap();
-        assert_eq!(*fen, board.get_fen());
+        assert_eq!(*fen, board.fen());
     }
 }

--- a/pleco/tests/fen_building.rs
+++ b/pleco/tests/fen_building.rs
@@ -10,7 +10,7 @@ use pleco::core::{PieceType, Player};
 #[test]
 fn basic_fen() {
     // Test if positions int he right place
-    let board = Board::new_from_fen("k6r/1p2b3/8/8/8/8/P4KPP/1B5R w KQkq - 0 3").unwrap();
+    let board = Board::from_fen("k6r/1p2b3/8/8/8/8/P4KPP/1B5R w KQkq - 0 3").unwrap();
     assert_eq!(board.count_piece(Player::White, PieceType::P), 3);
     assert_eq!(board.count_piece(Player::White, PieceType::N), 0);
     assert_eq!(board.count_piece(Player::White, PieceType::B), 1);
@@ -25,7 +25,7 @@ fn basic_fen() {
     assert_eq!(board.count_piece(Player::Black, PieceType::K), 1);
 
 
-    let board = Board::new_from_fen("8/2Q1pk2/nbpppppp/8/8/2K4N/PPPPPPPP/BBB2BBB w - - 0 10").unwrap();
+    let board = Board::from_fen("8/2Q1pk2/nbpppppp/8/8/2K4N/PPPPPPPP/BBB2BBB w - - 0 10").unwrap();
     assert_eq!(board.count_piece(Player::White, PieceType::P), 8);
     assert_eq!(board.count_piece(Player::White, PieceType::N), 1);
     assert_eq!(board.count_piece(Player::White, PieceType::B), 6);
@@ -43,7 +43,7 @@ fn basic_fen() {
 #[test]
 fn all_fens() {
     for fen in pleco::board::fen::ALL_FENS.iter() {
-        let board = Board::new_from_fen(*fen).unwrap();
+        let board = Board::from_fen(*fen).unwrap();
         assert_eq!(*fen, board.get_fen());
     }
 }

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco_engine"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"
@@ -67,7 +67,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.3.7" }
+pleco = { path = "../pleco", version = "0.3.8" }
 clippy = {version = "0.0.179", optional = true}
 chrono = "0.4.0"
 rand = "0.4.2"

--- a/pleco_engine/benches/depth_benches.rs
+++ b/pleco_engine/benches/depth_benches.rs
@@ -12,7 +12,7 @@ use pleco_engine::time::uci_timer::PreLimits;
 use test::{black_box, Bencher};
 
 #[bench]
-fn bench_3_ply(b: &mut Bencher) {
+fn engine_3_ply(b: &mut Bencher) {
     let mut limit = PreLimits::blank();
     limit.depth = Some(3);
     let board = Board::default();
@@ -27,7 +27,7 @@ fn bench_3_ply(b: &mut Bencher) {
 
 
 #[bench]
-fn bench_4_ply(b: &mut Bencher) {
+fn engine_4_ply(b: &mut Bencher) {
     let mut limit = PreLimits::blank();
     limit.depth = Some(4);
     let board = Board::default();
@@ -41,7 +41,7 @@ fn bench_4_ply(b: &mut Bencher) {
 
 
 #[bench]
-fn bench_5_ply(b: &mut Bencher) {
+fn engine_5_ply(b: &mut Bencher) {
     let mut limit = PreLimits::blank();
     limit.depth = Some(5);
     let board = Board::default();
@@ -54,7 +54,7 @@ fn bench_5_ply(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_6_ply(b: &mut Bencher) {
+fn engine_6_ply(b: &mut Bencher) {
     let mut limit = PreLimits::blank();
     limit.depth = Some(6);
     let board = Board::default();

--- a/pleco_engine/benches/eval_benches.rs
+++ b/pleco_engine/benches/eval_benches.rs
@@ -18,7 +18,7 @@ use pleco_engine::search::eval::Evaluation;
 lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         RAND_BOARD_NON_CHECKS_100.iter()
-            .map(|b| Board::new_from_fen(b).unwrap())
+            .map(|b| Board::from_fen(b).unwrap())
             .collect::<Vec<Board>>()
     };
 }

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -230,5 +230,17 @@ impl PlecoSearcher {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    #[test]
+    fn ply_3() {
+        let mut limit = PreLimits::blank();
+        limit.depth = Some(3);
+        let board = Board::default();
+        let mut s = PlecoSearcher::init(true);
+        s.search(&board, &limit);
+        s.await_move();
+
+    }
+
 
 }

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -236,10 +236,9 @@ mod tests {
         let mut limit = PreLimits::blank();
         limit.depth = Some(3);
         let board = Board::default();
-        let mut s = PlecoSearcher::init(true);
+        let mut s = PlecoSearcher::init(false);
         s.search(&board, &limit);
         s.await_move();
-
     }
 
 

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -43,7 +43,7 @@ impl RootMoveList {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.len.load(Ordering::SeqCst)
     }

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -328,8 +328,12 @@ impl Searcher {
             self.check_time();
         }
 
-        if depth == 0 || self.stop() {
-            return self.eval();
+        if depth == 0 {
+            if in_check {
+                return ZERO;
+            } else {
+                return self.eval();
+            }
         }
 
         if !at_root {
@@ -364,10 +368,8 @@ impl Searcher {
                                0, NodeBound::NoBound,
                                self.tt.time_age());
             }
-        }
 
-        // Futility Pruning
-        if !in_check {
+            // Futility Pruning
             if !at_root
                 && depth < 7
                 && pos_eval - futility_margin(depth) >= beta
@@ -375,6 +377,7 @@ impl Searcher {
                 return pos_eval;
             }
         }
+
 
         #[allow(unused_mut)]
         let mut moves: MoveList = if at_root {
@@ -511,7 +514,7 @@ impl Searcher {
 
 
         if ply >= MAX_PLY {
-            if ply >= MAX_PLY && !in_check {
+            if !in_check {
                 return self.eval();
             } else {
                 return ZERO;

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -5,6 +5,7 @@ pub mod eval;
 use std::cmp::{min,max};
 use std::sync::atomic::{Ordering,AtomicBool};
 use std::cell::UnsafeCell;
+use std::mem;
 
 use rand;
 use rand::Rng;
@@ -14,9 +15,10 @@ use pleco::core::*;
 use pleco::tools::tt::*;
 use pleco::core::score::*;
 use pleco::tools::pleco_arc::Arc;
+use pleco::board::movegen::{MoveGen,PseudoLegal};
+use pleco::core::mono_traits::{QuietChecksGenType};
 
-use MAX_PLY;
-use TT_TABLE;
+use {MAX_PLY,TT_TABLE,THREAD_STACK_SIZE};
 
 use threadpool::threadpool;
 use time::time_management::TimeManager;
@@ -29,6 +31,7 @@ use tables::material::Material;
 use tables::pawn_table::PawnTable;
 use consts::*;
 
+
 const THREAD_DIST: usize = 20;
 
 //                                      1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
@@ -36,8 +39,42 @@ static SKIP_SIZE: [u16; THREAD_DIST] = [1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4
 static START_PLY: [u16; THREAD_DIST] = [0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7];
 
 pub struct ThreadStack {
+    stack: [Stack; THREAD_STACK_SIZE],
+}
+
+impl ThreadStack {
+    pub fn new() -> Self {
+        unsafe {mem::zeroed()}
+    }
+
+    pub fn get(&mut self, frame: usize) -> &mut Stack {
+        debug_assert!(frame < THREAD_STACK_SIZE);
+        unsafe {
+            self.stack.get_unchecked_mut(frame)
+        }
+    }
+
+    pub fn ply_zero(&mut self) -> &mut Stack {
+        self.get(4)
+    }
+}
+
+pub struct Stack {
     pv: BitMove,
     ply: u16,
+}
+
+impl Stack {
+    pub fn offset(&mut self, count: isize) -> &mut Stack {
+        unsafe {
+            let ptr: *mut Stack = self as *mut Stack;
+            &mut *ptr.offset(count)
+        }
+    }
+
+    pub fn incr(&mut self) -> &mut Stack {
+        self.offset(1)
+    }
 }
 
 pub struct Searcher {
@@ -56,6 +93,7 @@ pub struct Searcher {
     pub pawns: PawnTable,
     pub material: Material,
     pub root_moves: UnsafeCell<RootMoveList>,
+    pub selected_depth: u16,
 
     // MainThread Information
     pub previous_score: Value,
@@ -80,6 +118,7 @@ impl Searcher {
             pawns: PawnTable::new(16384),
             material: Material::new(8192),
             root_moves: UnsafeCell::new(RootMoveList::new()),
+            selected_depth: 0,
             previous_score: 0
         }
     }
@@ -111,6 +150,7 @@ impl Searcher {
             TIMER.init(self.limit.start.clone(), &timer, self.board.turn(), self.board.moves_played());
         }
 
+        self.tt.new_search();
         // Start each of the threads!
         threadpool().thread_cond.set();
 
@@ -182,6 +222,8 @@ impl Searcher {
         let mut time_reduction: f64 = 1.0;
         let mut last_best_move: BitMove = BitMove::null();
         let mut best_move_stability: u32 = 0;
+        let mut stack: ThreadStack = ThreadStack::new();
+        let ss: &mut Stack = stack.ply_zero();
 
         self.shuffle();
 
@@ -199,7 +241,7 @@ impl Searcher {
 
             'aspiration_window: loop {
 
-                best_value = self.search::<PV>(alpha, beta, depth) as i32;
+                best_value = self.search::<PV>(alpha, beta, ss,depth) as i32;
                 self.root_moves().sort();
 
                 if self.stop() {
@@ -259,18 +301,17 @@ impl Searcher {
                     }
                 }
             }
-
         }
     }
 
-    fn search<N: PVNode>(&mut self, mut alpha: i32, beta: i32, max_depth: u16) -> i32 {
+    fn search<N: PVNode>(&mut self, mut alpha: i32, beta: i32, ss: &mut Stack, depth: u16) -> i32 {
         let is_pv: bool = N::is_pv();
-        let at_root: bool = self.board.depth() == 0;
+        let ply: u16 = ss.ply;
+        let at_root: bool = ply == 0;
         let zob: u64 = self.board.zobrist();
         let (tt_hit, tt_entry): (bool, &mut Entry) = TT_TABLE.probe(zob);
         let tt_value: Value = if tt_hit {tt_entry.score as i32} else {0};
         let in_check: bool = self.board.in_check();
-        let ply: u16 = self.board.depth();
 
         let mut best_move = BitMove::null();
 
@@ -280,15 +321,16 @@ impl Searcher {
 
         let mut pos_eval: i32 = 0;
 
+        // increment the next ply
+        ss.incr().ply = ply + 1;
+
         if self.main_thread() {
             self.check_time();
         }
 
-        if ply >= max_depth || self.stop() {
+        if depth == 0 || self.stop() {
             return self.eval();
         }
-
-        let plys_to_zero = max_depth - ply;
 
         if !at_root {
             if alpha >= beta {
@@ -298,14 +340,13 @@ impl Searcher {
 
         if !is_pv
             && tt_hit
-            && tt_entry.depth as u16 >= plys_to_zero
-            && tt_entry.eval != 0
+            && tt_entry.depth as u16 >= depth
             && tt_value != 0
-            && pos_eval != 0
             && correct_bound_eq(tt_value, beta, tt_entry.node_type()) {
             return tt_value;
         }
 
+        // Get and set the position eval
         if in_check {
             pos_eval = 0;
         } else {
@@ -318,14 +359,19 @@ impl Searcher {
                 }
             } else {
                 pos_eval = self.eval();
-                tt_entry.place(zob, BitMove::null(), 0, pos_eval as i16, 0, NodeBound::NoBound);
+                tt_entry.place(zob, BitMove::null(),
+                               0, pos_eval as i16,
+                               0, NodeBound::NoBound,
+                               self.tt.time_age());
             }
         }
 
+        // Futility Pruning
         if !in_check {
-            if ply > 3
-                && ply < 7
-                && pos_eval - futility_margin(ply) >= beta && pos_eval < 10000 {
+            if !at_root
+                && depth < 7
+                && pos_eval - futility_margin(depth) >= beta
+                && pos_eval < 10000 {
                 return pos_eval;
             }
         }
@@ -339,7 +385,7 @@ impl Searcher {
 
         if moves.is_empty() {
             if self.board.in_check() {
-                return MATE as i32 - (ply as i32);
+                return -MATE as i32 + (ply as i32);
             } else {
                 return DRAW as i32;
             }
@@ -356,33 +402,40 @@ impl Searcher {
                 let gives_check: bool = self.board.gives_check(*mov);
                 self.board.apply_unknown_move(*mov, gives_check);
                 self.tt.prefetch(self.board.zobrist());
-                let do_full_depth: bool = if max_depth >= 3 && moves_played > 1 && ply >= 2 {
-                    if in_check || gives_check {
-                        value = -self.search::<NonPV>(-(alpha+1), -alpha, max_depth - 1);
-                    } else {
-                        value = -self.search::<NonPV>(-(alpha+1), -alpha, max_depth - 2);
-                    }
+                let do_full_depth: bool = if depth >= 3 && moves_played > 1 && !mov.is_capture() && !mov.is_promo() {
+                    let new_depth = if in_check || gives_check {depth - 2} else {depth - 3};
+                    value = -self.search::<NonPV>(-(alpha+1), -alpha, ss.incr(), new_depth);
                     value > alpha
                 } else {
                     !is_pv || moves_played > 1
                 };
                 if do_full_depth {
-                    value = -self.search::<NonPV>(-(alpha+1), -alpha, max_depth);
+                    value = if depth - 1 < 1 {
+                        if gives_check {
+                            -self.qsearch::<NonPV,InCheck>(-(alpha+1), -alpha, ss.incr(), 0)
+                        } else {
+                            -self.qsearch::<NonPV,NoCheck>(-(alpha+1), -alpha, ss.incr(), 0)
+                        }
+                    } else {
+                        -self.search::<NonPV>(-(alpha+1), -alpha, ss.incr(),  depth - 1)
+                    };
                 }
                 if is_pv && (moves_played == 1 || (value > alpha && (at_root || value < beta))) {
-                    value = -self.search::<PV>(-beta, -alpha, max_depth);
+                    value = -self.search::<PV>(-beta, -alpha, ss.incr(),depth -1);
                 }
                 self.board.undo_move();
                 assert!(value > NEG_INFINITE);
                 assert!(value < INFINITE );
+
                 if self.stop() {
                     return 0;
                 }
+
                 if at_root {
                     let rm: &mut RootMove = unsafe { self.root_moves().get_unchecked_mut(i) };
 
                     if moves_played == 1 || value > alpha {
-                        rm.depth_reached = max_depth;
+                        rm.depth_reached = depth;
                         rm.score = value;
 
                     } else {
@@ -398,7 +451,10 @@ impl Searcher {
                         if is_pv && value < beta {
                             alpha = value;
                         } else {
-                            break;
+                            tt_entry.place(zob, best_move, best_value as i16,
+                                           pos_eval as i16, depth as i16,
+                                           NodeBound::LowerBound, self.tt.time_age());
+                            return value;
                         }
                     }
                 }
@@ -418,12 +474,162 @@ impl Searcher {
                 else {NodeBound::UpperBound};
 
 
-        tt_entry.place(zob, best_move, best_value as i16, pos_eval as i16, plys_to_zero as u8, node_bound);
+        tt_entry.place(zob, best_move, best_value as i16,
+                       pos_eval as i16, depth as i16,
+                       node_bound, self.tt.time_age());
 
         best_value
     }
 
     // TODO: Qscience search
+    fn qsearch<N: PVNode, C: CheckState>(&mut self, mut alpha: i32, beta: i32, ss: &mut Stack, rev_depth: i16) -> i32 {
+        let is_pv: bool = N::is_pv();
+        let in_check: bool = C::in_check();
+
+        assert!(alpha >= NEG_INFINITE);
+        assert!(beta <= INFINITE);
+        assert!(alpha < beta);
+        assert!(rev_depth <= 0);
+        assert!(is_pv || (alpha == beta - 1));
+//        assert_eq!(in_check, self.board.in_check());
+
+        if in_check != self.board.in_check() {
+            self.board.pretty_print();
+        }
+
+
+        let ply: u16 = ss.ply;
+        let zob: u64 = self.board.zobrist();
+        let (tt_hit, tt_entry): (bool, &mut Entry) = TT_TABLE.probe(zob);
+        let tt_value: Value = if tt_hit {tt_entry.score as i32} else {0};
+
+        let mut best_move = BitMove::null();
+
+        let mut value: Value;
+        let mut best_value: Value = NEG_INFINITE;
+        let mut pos_eval: Value = NEG_INFINITE;
+        let mut moves_played = 0;
+        let tt_depth: i16 = if in_check || rev_depth >= 0 {0} else {-1};
+
+        // increment the next ply
+        ss.incr().ply = ply + 1;
+
+        if ply >= MAX_PLY {
+            if ply >= MAX_PLY && !in_check {
+                return self.eval();
+            } else {
+                return NONE;
+            }
+        }
+
+        if !is_pv
+            && tt_hit
+            && tt_entry.depth as i16 >= tt_depth
+            && tt_value != 0
+            && correct_bound_eq(tt_value, beta, tt_entry.node_type()) {
+            return tt_value;
+        }
+
+        if !in_check {
+            if tt_hit {
+                if tt_entry.eval == 0 {
+                    best_value = self.eval();
+                    pos_eval = best_value;
+                } else {
+                    best_value = tt_entry.eval as i32;
+                    pos_eval = best_value;
+                }
+
+                if tt_value != 0 && correct_bound(tt_value, best_value, tt_entry.node_type()) {
+                    best_value == tt_value;
+                }
+            } else {
+                best_value = self.eval();
+                pos_eval = best_value;
+            }
+
+            if best_value >= beta {
+                if !tt_hit {
+                    tt_entry.place(zob, BitMove::null(), best_value as i16,
+                                   pos_eval as i16, 0,
+                                   NodeBound::LowerBound, self.tt.time_age());
+                }
+                return best_value;
+            }
+
+            if is_pv && best_value > alpha {
+                alpha = best_value;
+            }
+        }
+
+        let moves: MoveList = if in_check {
+            self.board.generate_pseudolegal_moves_of_type(GenTypes::Evasions)
+        } else {
+            let mut list = self.board.generate_pseudolegal_moves_of_type(GenTypes::Evasions);
+            unsafe {
+                MoveGen::extend::<PseudoLegal,QuietChecksGenType,MoveList>(&self.board, &mut list);
+            }
+            list
+        };
+
+        if moves.is_empty() {
+            if self.board.in_check() {
+                return -MATE as i32 + (ply as i32);
+            } else {
+                return pos_eval as i32;
+            }
+        }
+
+        for  mov in moves.iter() {
+            if self.board.legal_move(*mov) {
+                moves_played += 1;
+                let gives_check: bool = self.board.gives_check(*mov);
+                self.board.apply_unknown_move(*mov, gives_check);
+                self.tt.prefetch(self.board.zobrist());
+
+                value = if gives_check {
+                    -self.qsearch::<N,InCheck>(-beta, -alpha, ss.incr(),rev_depth -1)
+                } else {
+                    -self.qsearch::<N,NoCheck>(-beta, -alpha, ss.incr(),rev_depth -1)
+                };
+
+                self.board.undo_move();
+
+                assert!(value > NEG_INFINITE);
+                assert!(value < INFINITE );
+
+                if value > best_value {
+                    best_value = value;
+
+                    if value > alpha {
+                        best_move = *mov;
+                        if is_pv && value < beta {
+                            alpha = value;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if moves_played == 0 {
+            best_value = 0;
+        }
+
+        let node_bound = if best_value as i32 >= beta {NodeBound::LowerBound}
+            else if is_pv && !best_move.is_null() {NodeBound::Exact}
+                else {NodeBound::UpperBound};
+
+
+        tt_entry.place(zob, best_move, best_value as i16,
+                       pos_eval as i16, rev_depth,
+                       node_bound, self.tt.time_age());
+
+
+        best_value
+    }
+
 
     pub fn eval(&mut self) -> Value {
         let pawns = &mut self.pawns;

--- a/pleco_engine/src/tables/material.rs
+++ b/pleco_engine/src/tables/material.rs
@@ -47,10 +47,10 @@ pub struct MaterialEntry {
 
 
 impl MaterialEntry {
+    #[inline(always)]
     pub fn score(&self) -> Score {
         Score(self.value, self.value)
     }
-
 }
 
 

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -187,49 +187,58 @@ pub struct PawnEntry {
 impl PawnEntry {
 
     /// Returns the current score of the pawn scructure.
+    #[inline(always)]
     pub fn pawns_score(&self) -> Score {
         self.score
     }
 
     /// Returns the possible pawn attacks `BitBoard` of a player.
+    #[inline(always)]
     pub fn pawn_attacks(&self, player: Player) -> BitBoard {
         self.pawn_attacks[player as usize]
     }
 
     /// Returns the `BitBoard` of the passed pawns for a specified player. A passed pawn is one that
     /// has no opposing pawns in the same file, or any adjacent file.
+    #[inline(always)]
     pub fn passed_pawns(&self, player: Player) -> BitBoard {
         self.passed_pawns[player as usize]
     }
 
     /// Returns the span of all the pawn's attacks for a given player.
+    #[inline(always)]
     pub fn pawn_attacks_span(&self, player: Player) -> BitBoard {
         self.pawn_attacks_span[player as usize]
     }
 
     /// Returns the weak-unopposed score of the given player. This measures the strength of the pawn
     /// structure when considering isolated and disconnected pawns.
+    #[inline(always)]
     pub fn weak_unopposed(&self, player: Player) -> i16 {
         self.weak_unopposed[player as usize]
     }
 
     /// Assymetric score of a position.
+    #[inline(always)]
     pub fn asymmetry(&self) -> i16 {
         self.asymmetry
     }
 
     /// Returns a bitfield of the current ranks.
+    #[inline(always)]
     pub fn open_files(&self) -> u8 {
         self.open_files
     }
 
     /// Returns if a file is semi-open for a given player, meaning there are no pieces of the
     /// opposing player on that file.
+    #[inline]
     pub fn semiopen_file(&self, player: Player, file: File) -> bool {
         self.semiopen_files[player as usize] & (1 << file as u8) != 0
     }
 
     /// Returns if a side of a file is semi-open, meaning no enemy pieces.
+    #[inline]
     pub fn semiopen_side(&self, player: Player, file: File, left_side: bool) -> bool {
         let side_mask: u8 = if left_side {
             file.left_side_mask()
@@ -240,6 +249,7 @@ impl PawnEntry {
     }
 
     // returns count of pawns of a player on the same color square as the player's color.
+    #[inline]
     pub fn pawns_on_same_color_squares(&self, player: Player, sq: SQ) -> u8 {
         self.pawns_on_squares[player as usize][sq.square_color_index()]
     }

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -123,6 +123,7 @@ impl ThreadPool {
     }
 
     /// Returns the number of threads
+    #[inline(always)]
     fn size(&self) -> usize {
         self.threads.len()
     }
@@ -147,6 +148,7 @@ impl ThreadPool {
 
 
     /// Sets the use of standard out. This can be changed mid search as well.
+    #[inline(always)]
     pub fn stdout(&mut self, use_stdout: bool) {
         USE_STDOUT.store(use_stdout, Ordering::Relaxed);
     }
@@ -197,6 +199,7 @@ impl ThreadPool {
     }
 
     /// Sets the threads to stop (or not!).
+    #[inline(always)]
     pub fn set_stop(&mut self, stop: bool) {
         self.stop.store(stop, Ordering::Relaxed);
     }

--- a/pleco_engine/src/time/time_management.rs
+++ b/pleco_engine/src/time/time_management.rs
@@ -26,6 +26,7 @@ enum TimeCalc {
 }
 
 impl TimeCalc {
+    #[inline(always)]
     pub fn t_max_ratio(&self) -> f64 {
         match *self {
             TimeCalc::Ideal => 1.0,
@@ -33,6 +34,7 @@ impl TimeCalc {
         }
     }
 
+    #[inline(always)]
     pub fn t_steal_ratio(&self) -> f64 {
         match *self {
             TimeCalc::Ideal => 0.0,
@@ -100,7 +102,6 @@ impl TimeManager {
             let start = &*self.start.get();
             start.clone()
         }
-
     }
 
     pub fn elapsed(&self) -> i64 {
@@ -139,12 +140,14 @@ impl TimeManager {
         (my_time as f64 * ratio1.min(ratio2)) as i64
     }
 
+    #[inline(always)]
     pub fn maximum_time(&self) -> i64 {
         unsafe {
             *self.maximum_time.get()
         }
     }
 
+    #[inline(always)]
     pub fn ideal_time(&self) -> i64 {
         unsafe {
             *self.ideal_time.get()

--- a/pleco_engine/src/uci/parse.rs
+++ b/pleco_engine/src/uci/parse.rs
@@ -153,7 +153,7 @@ pub fn setboard_parse_board(args: &[&str]) -> Option<Board> {
                                       .map(|p| (*p).to_string())
                                       .collect::<Vec<String>>()
                                       .join(" ");
-    Board::new_from_fen(&fen_string).ok()
+    Board::from_fen(&fen_string).ok()
 }
 
 pub fn position_parse_board(args: &[&str]) -> Option<Board> {
@@ -166,7 +166,7 @@ pub fn position_parse_board(args: &[&str]) -> Option<Board> {
                                           .map(|p| (*p).to_string())
                                           .collect::<Vec<String>>()
                                           .join(" ");
-        Board::new_from_fen(&fen_string).ok()
+        Board::from_fen(&fen_string).ok()
     } else {
         None
     };


### PR DESCRIPTION
Updated `pleco` to 0.3.8

Changes
- `Board::new_from_fen` changes to `Board::from_fen`.
- `Board::get_fen` changes to `Board::fen`.
- new perft tests, currently only failing 1, the kiwipete test.
- Improved speed of `Player::relative_rank`.
- new const functions and inlining
- Changed `BitMove` masks to `const` instead of `static`.
- `TranspositionTable::Entry` depth is now a i8 (for qsearch)

Updated `pleco_engine` to 0.0.12

Changes
- Preliminary quiescence search! Wahoo!
- Fixed the terrible move playing due to returning the wring constant `Value`.
- `ThreadStack` for the searcher to keep track of the PV and ply at each depth.
- Changed decrementing of `max_depth`
