### PR TITLE
Better TimeManagement, Bot simplification, MoveGen improvements, Better engine playing.

### DIFF
--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -68,7 +68,7 @@ doctest = true
 
 
 [dependencies]
-clippy = {version = "0.0.186", optional = true}
+clippy = {version = "0.0.187", optional = true}
 bitflags = "1.0.1"
 rand = "0.4.2"
 rayon = "1.0.0"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -74,6 +74,7 @@ rand = "0.4.2"
 rayon = "1.0.0"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
+mucow = "0.1.0"
 
 [dependencies.lazy_static]
 version = "1.0.0"

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -529,7 +529,7 @@ impl Board {
         // Create the Board States
         let mut board_s = UniqueArc::new(BoardState {
             castling: castle_bytes,
-            rule_50: rule_50,
+            rule_50,
             ply: 0,
             ep_square: ep_sq,
             psq: Score::ZERO,
@@ -548,7 +548,7 @@ impl Board {
 
         // Create the Board
         let mut b = Board {
-            turn: turn,
+            turn,
             bit_boards: [[BitBoard(0); PIECE_TYPE_CNT]; PLAYER_CNT],
             occ: [BitBoard(0), BitBoard(0)],
             occ_all: BitBoard(0),
@@ -1138,26 +1138,20 @@ impl Board {
 
         // Set the Pinners and Blockers
         let mut white_pinners: BitBoard = BitBoard(0);
-        // TODO: NLL
-        {
-            board_state.blockers_king[Player::White as usize] = self.slider_blockers(
-                self.occupied_black(),
-                self.king_sq(Player::White),
-                &mut white_pinners,
-            )
-        };
+
+        board_state.blockers_king[Player::White as usize] = self.slider_blockers(
+            self.occupied_black(),
+            self.king_sq(Player::White),
+            &mut white_pinners);
 
         board_state.pinners_king[Player::White as usize] = white_pinners;
 
-        // TODO: NLL
         let mut black_pinners: BitBoard = BitBoard(0);
-        {
-            board_state.blockers_king[Player::Black as usize] = self.slider_blockers(
-                self.occupied_white(),
-                self.king_sq(Player::Black),
-                &mut black_pinners,
-            )
-        };
+
+        board_state.blockers_king[Player::Black as usize] = self.slider_blockers(
+            self.occupied_white(),
+            self.king_sq(Player::Black),
+            &mut black_pinners);
 
         board_state.pinners_king[Player::Black as usize] = black_pinners;
 
@@ -1168,8 +1162,8 @@ impl Board {
         board_state.check_sqs[PieceType::N as usize] = knight_moves(ksq);
         board_state.check_sqs[PieceType::B as usize] = bishop_moves(occupied, ksq);
         board_state.check_sqs[PieceType::R as usize] = rook_moves(occupied, ksq);
-        board_state.check_sqs[PieceType::Q as usize] = board_state.check_sqs[PieceType::B as usize] |
-            board_state.check_sqs[PieceType::R as usize];
+        board_state.check_sqs[PieceType::Q as usize] = board_state.check_sqs[PieceType::B as usize]
+            | board_state.check_sqs[PieceType::R as usize];
         board_state.check_sqs[PieceType::K as usize] = BitBoard(0);
     }
 

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -17,7 +17,7 @@ use std::cmp::{PartialEq,max,min};
 use rand;
 
 use core::piece_move::{BitMove, MoveType};
-use core::move_list::MoveList;
+use core::move_list::{MoveList,ScoringMoveList};
 use core::mono_traits::*;
 use core::masks::*;
 use core::sq::{SQ,NO_SQ};
@@ -1063,6 +1063,10 @@ impl Board {
         MoveGen::generate::<Legal, AllGenType>(self)
     }
 
+    pub fn generate_scoring_moves(&self) -> ScoringMoveList {
+        MoveGen::generate_scoring::<Legal, AllGenType>(self)
+    }
+
     /// Get a List of all PseudoLegal `BitMove`s for the player whose turn it is to move.
     /// Works exactly the same as `Board::generate_moves()`, but doesn't guarantee that all
     /// the moves are legal for the current position. Moves need to be checked with a
@@ -1819,6 +1823,13 @@ impl Board {
     #[inline(always)]
     pub fn pawn_passed(&self, player: Player, sq: SQ) -> bool {
         (self.piece_bb(player.other_player(), PieceType::P) & passed_pawn_mask(player, sq)).is_empty()
+    }
+
+    /// Checks if a move is an advanced pawn push, meaning it passes into enemy territory.
+    #[inline(always)]
+    pub fn advanced_pawn_push(&self, mov: BitMove) -> bool {
+        self.piece_at_sq(mov.get_src()) == Some(PieceType::P)
+            && self.turn().relative_rank_of_sq(mov.get_src()) > Rank::R4
     }
 
 //  ------- Move Testing -------

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -57,7 +57,6 @@ use std::ops::Index;
 
 use board::*;
 
-use core::mono_traits::*;
 use core::piece_move::{MoveFlag, BitMove, PreMoveInfo, ScoringMove};
 use core::move_list::{MoveList,ScoringMoveList,MVPushable};
 
@@ -177,7 +176,7 @@ impl MoveGen {
     /// `MVPushable::unchecked_set_len(...)` to set the size manually after this method.
     #[inline(always)]
     pub unsafe fn extend_from_ptr<L: Legality, G: GenTypeTrait, MP: MVPushable>(chessboard: &Board, ptr: *mut MP::Output)
-        -> *mut MP::Output
+                                                                                -> *mut MP::Output
         where <MP as Index<usize>>::Output : Sized
     {
         InnerMoveGen::<MP>::generate::<L,G>(chessboard, ptr)
@@ -190,8 +189,6 @@ impl MoveGen {
 struct InnerMoveGen<'a, MP: MVPushable + 'a> {
     ptr: *mut MP::Output,
     board: &'a Board,
-    us: Player,
-    them: Player,
     occ: BitBoard,
     // Squares occupied by all
     us_occ: BitBoard,
@@ -204,11 +201,10 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
     /// Returns a pointer to the last element of all moves for a given board, Legality & GenType.
     #[inline(always)]
     fn generate<L: Legality, G: GenTypeTrait>(chessboard: &Board, movelist: *mut MP::Output) -> *mut MP::Output {
-        InnerMoveGen::<MP>::generate_helper::<L, G>(chessboard, movelist)
-//        match chessboard.turn() {
-//            Player::White => InnerMoveGen::<MP>::generate_helper::<L, G, WhiteType>(chessboard, movelist),
-//            Player::Black => InnerMoveGen::<MP>::generate_helper::<L, G, BlackType>(chessboard, movelist)
-//        }
+        match chessboard.turn() {
+            Player::White => InnerMoveGen::<MP>::generate_helper::<L, G, WhiteType>(chessboard, movelist),
+            Player::Black => InnerMoveGen::<MP>::generate_helper::<L, G, BlackType>(chessboard, movelist)
+        }
     }
 
     // Helper function to setup the MoveGen structure.
@@ -217,8 +213,6 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
         InnerMoveGen {
             ptr,
             board: chessboard,
-            us: chessboard.turn(),
-            them: chessboard.turn().other_player(),
             occ: chessboard.get_occupied(),
             us_occ: chessboard.get_occupied_player(chessboard.turn()),
             them_occ: chessboard.get_occupied_player(chessboard.turn().other_player()),
@@ -226,27 +220,27 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
     }
 
     /// Directly generates the moves.
-    fn generate_helper<L: Legality, G: GenTypeTrait>(chessboard: &Board, ptr: *mut MP::Output) -> *mut MP::Output{
+    fn generate_helper<L: Legality, G: GenTypeTrait, P: PlayerTrait>(chessboard: &Board, ptr: *mut MP::Output) -> *mut MP::Output{
         let mut movegen = InnerMoveGen::<MP>::get_self(chessboard, ptr);
         let gen_type = G::gen_type();
         if gen_type == GenTypes::Evasions {
-            movegen.generate_evasions::<L>();
+            movegen.generate_evasions::<L, P>();
         } else if gen_type == GenTypes::QuietChecks {
-            movegen.generate_quiet_checks::<L>();
+            movegen.generate_quiet_checks::<L, P>();
         } else if gen_type == GenTypes::All {
             if movegen.board.in_check() {
-                movegen.generate_evasions::<L>();
+                movegen.generate_evasions::<L, P>();
             } else {
-                movegen.generate_non_evasions::<L, NonEvasionsGenType>();
+                movegen.generate_non_evasions::<L, NonEvasionsGenType, P>();
             }
         } else {
-            movegen.generate_non_evasions::<L, G>();
+            movegen.generate_non_evasions::<L, G, P>();
         }
         movegen.ptr
     }
 
     /// Generates non-evasions, ala the board is in check.
-    fn generate_non_evasions<L: Legality, G: GenTypeTrait>(&mut self) {
+    fn generate_non_evasions<L: Legality, G: GenTypeTrait, P: PlayerTrait>(&mut self) {
         assert_ne!(G::gen_type(), GenTypes::All);
         assert_ne!(G::gen_type(), GenTypes::QuietChecks);
         assert_ne!(G::gen_type(), GenTypes::Evasions);
@@ -260,38 +254,30 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             _ => unreachable!()
         };
 
-        self.generate_all::<L, G>(target);
+        self.generate_all::<L, G, P>(target);
     }
 
     /// Generates all moves of a certain legality, `GenType`, and player. The target is the
     /// bitboard of the squares where moves should be generated.
-    fn generate_all<L: Legality, G: GenTypeTrait>(&mut self, target: BitBoard) {
-        match self.us {
-            Player::White => self.generate_pawn_moves::<L, G, WhiteType>(target),
-            Player::Black => self.generate_pawn_moves::<L, G, BlackType>(target),
-        }
-//        self.generate_pawn_moves::<L, G, P>(target);
-        self.moves_per_piece::<L, KnightType>(target);
-        self.moves_per_piece::<L, BishopType>(target);
-        self.moves_per_piece::<L, RookType>(target);
-        self.moves_per_piece::<L, QueenType>(target);
+    fn generate_all<L: Legality, G: GenTypeTrait, P: PlayerTrait>(&mut self, target: BitBoard) {
+        self.generate_pawn_moves::<L, G, P>(target);
+        self.moves_per_piece::<L, P, KnightType>(target);
+        self.moves_per_piece::<L, P, BishopType>(target);
+        self.moves_per_piece::<L, P, RookType>(target);
+        self.moves_per_piece::<L, P, QueenType>(target);
 
         if G::gen_type() != GenTypes::QuietChecks && G::gen_type() != GenTypes::Evasions {
-            self.moves_per_piece::<L, KingType>(target);
+            self.moves_per_piece::<L, P, KingType>(target);
         }
 
         if G::gen_type() != GenTypes::Captures && G::gen_type() != GenTypes::Evasions
-            && (self.board.can_castle(self.us, CastleType::KingSide) || self.board.can_castle(self.us, CastleType::QueenSide)) {
-            match self.us {
-                Player::White => self.generate_castling::<L, WhiteType>(),
-                Player::Black => self.generate_castling::<L, BlackType>(),
-            }
-//            self.generate_castling::<L, P>();
+            && (self.board.can_castle(P::player(), CastleType::KingSide) || self.board.can_castle(P::player(), CastleType::QueenSide)) {
+            self.generate_castling::<L, P>();
         }
     }
 
     /// Generates quiet checks.
-    fn generate_quiet_checks<L: Legality>(&mut self) {
+    fn generate_quiet_checks<L: Legality, P: PlayerTrait>(&mut self) {
         assert!(!self.board.in_check());
         let mut disc_check: BitBoard = self.board.discovered_check_candidates();
 
@@ -299,22 +285,22 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
         while let Some(from) = disc_check.pop_some_lsb() {
             let piece: PieceType = self.board.piece_at_sq(from).unwrap();
             if piece != PieceType::P {
-                let mut b: BitBoard = self.moves_bb_nm(piece, from) & !self.board.get_occupied();
+                let mut b: BitBoard = self.moves_bb(piece, from) & !self.board.get_occupied();
                 if piece == PieceType::K {
-                    b &= queen_moves(BitBoard(0), self.board.king_sq(self.them))
+                    b &= queen_moves(BitBoard(0), self.board.king_sq(P::opp_player()))
                 }
                 self.move_append_from_bb_flag::<L>(&mut b, from, BitMove::FLAG_QUIET);
             }
         }
-        self.generate_all::<L, QuietChecksGenType>(!self.board.get_occupied());
+        self.generate_all::<L, QuietChecksGenType, P>(!self.board.get_occupied());
     }
 
 
     // Helper function to generate evasions
-    fn generate_evasions<L: Legality>(&mut self) {
+    fn generate_evasions<L: Legality, P: PlayerTrait>(&mut self) {
         assert!(self.board.in_check());
 
-        let ksq: SQ = self.board.king_sq(self.us);
+        let ksq: SQ = self.board.king_sq(P::player());
         let mut slider_attacks: BitBoard = BitBoard(0);
 
         // Pieces that could possibly attack the king with sliding attacks
@@ -340,18 +326,16 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
 
             // Squares that allow a block or capture of the sliding piece
             let target: BitBoard = between_bb(checking_sq, ksq) | checking_sq.to_bb();
-            self.generate_all::<L, EvasionsGenType>(target);
+            self.generate_all::<L, EvasionsGenType, P>(target);
         }
     }
 
     // Generate king moves with a given target
-    #[inline(always)]
-    fn generate_king_moves<L: Legality>(&mut self, target: BitBoard) {
-        self.moves_per_piece::<L, KingType>(target);
+    fn generate_king_moves<L: Legality, P: PlayerTrait>(&mut self, target: BitBoard) {
+        self.moves_per_piece::<L, P, KingType>(target);
     }
 
     // Generates castling for both sides
-    #[inline(always)]
     fn generate_castling<L: Legality, P: PlayerTrait>(&mut self) {
         self.castling_side::<L, P>(CastleType::QueenSide);
         self.castling_side::<L, P>(CastleType::KingSide);
@@ -405,19 +389,19 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
     }
 
     // Generate non-pawn and non-king moves for a target
-    fn gen_non_pawn_king<L: Legality>(&mut self, target: BitBoard) {
-        self.moves_per_piece::<L, KnightType>(target);
-        self.moves_per_piece::<L, BishopType>(target);
-        self.moves_per_piece::<L, RookType>(target);
-        self.moves_per_piece::<L, QueenType>(target);
+    fn gen_non_pawn_king<L: Legality, P: PlayerTrait>(&mut self, target: BitBoard) {
+        self.moves_per_piece::<L, P, KnightType>(target);
+        self.moves_per_piece::<L, P, BishopType>(target);
+        self.moves_per_piece::<L, P, RookType>(target);
+        self.moves_per_piece::<L, P, QueenType>(target);
     }
 
 
     // Get the captures and non-captures for a piece
-    fn moves_per_piece<L: Legality, P: PieceTrait>(&mut self, target: BitBoard) {
-        let mut piece_bb: BitBoard = self.board.piece_bb(self.us, P::piece_type());
+    fn moves_per_piece<L: Legality, PL: PlayerTrait, P: PieceTrait>(&mut self, target: BitBoard) {
+        let mut piece_bb: BitBoard = self.board.piece_bb(PL::player(), P::piece_type());
         while let Some(src) = piece_bb.pop_some_lsb() {
-            let moves_bb: BitBoard = self.moves_bb::<P>(src) & !self.us_occ & target;
+            let moves_bb: BitBoard = self.moves_bb2::<P>(src) & !self.us_occ & target;
             let mut captures_bb: BitBoard = moves_bb & self.them_occ;
             let mut non_captures_bb: BitBoard = moves_bb & !self.them_occ;
             self.move_append_from_bb_flag::<L>(&mut captures_bb, src, BitMove::FLAG_CAPTURE);
@@ -568,7 +552,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
 
     // Return the moves Bitboard
     #[inline]
-    fn moves_bb_nm(&self, piece: PieceType, square: SQ) -> BitBoard {
+    fn moves_bb(&self, piece: PieceType, square: SQ) -> BitBoard {
         debug_assert!(square.is_okay());
         debug_assert_ne!(piece, PieceType::P);
         match piece {
@@ -581,8 +565,11 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
         }
     }
 
+    // Note: Does including this truly decrease MoveGen timing?
+
+    /// Return the moves Bitboard
     #[inline]
-    fn moves_bb<P: PieceTrait>(&self, square: SQ) -> BitBoard {
+    fn moves_bb2<P: PieceTrait>(&self, square: SQ) -> BitBoard {
         debug_assert!(square.is_okay());
         debug_assert_ne!(P::piece_type(), PieceType::P);
         match P::piece_type() {
@@ -594,6 +581,8 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             PieceType::K => king_moves(square),
         }
     }
+
+
 
     #[inline]
     fn move_append_from_bb_flag<L: Legality>(&mut self, bits: &mut BitBoard, src: SQ, flag_bits: u16) {
@@ -675,8 +664,8 @@ mod tests {
     #[test]
     fn movegen_list_sim_all() {
         let boards: Vec<Board> = ALL_FENS.iter()
-            .map(|f| Board::from_fen(*f).unwrap())
-            .collect();
+                                         .map(|f| Board::from_fen(*f).unwrap())
+                                         .collect();
 
         boards.iter().for_each(|b| {
             let mb = b.generate_moves();

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -600,7 +600,6 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
                 let b_ptr = mem::transmute::<*mut MP::Output, *mut BitMove>(self.ptr);
                 ptr::write(b_ptr, b_move);
                 self.ptr = self.ptr.add(1);
-//                self.movelist.unchecked_push_mv(b_move)
             };
         }
     }

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -57,7 +57,7 @@ use std::ops::Index;
 
 use board::*;
 
-use core::piece_move::{MoveFlag, BitMove, PreMoveInfo, ScoringBitMove};
+use core::piece_move::{MoveFlag, BitMove, PreMoveInfo, ScoringMove};
 use core::move_list::{MoveList,ScoringMoveList,MVPushable};
 
 use {SQ, BitBoard};
@@ -139,9 +139,9 @@ impl MoveGen {
     pub fn generate_scoring<L: Legality, G: GenTypeTrait>(chessboard: &Board) -> ScoringMoveList {
         let mut movelist = ScoringMoveList::default();
         unsafe {
-            let ptr: *mut ScoringBitMove = movelist.as_mut_ptr();
+            let ptr: *mut ScoringMove = movelist.as_mut_ptr();
             let new_ptr = InnerMoveGen::<ScoringMoveList>::generate::<L, G>(chessboard, ptr);
-            let new_size = (new_ptr as usize - ptr as usize) / mem::size_of::<ScoringBitMove>();
+            let new_size = (new_ptr as usize - ptr as usize) / mem::size_of::<ScoringMove>();
             movelist.unchecked_set_len(new_size);
         }
         movelist

--- a/pleco/src/board/pgn.rs
+++ b/pleco/src/board/pgn.rs
@@ -332,7 +332,7 @@ impl PGN {
             tags = tags.add(line)?;
         }
         Ok(PGN {
-            tags: tags,
+            tags,
             moves: Vec::new()
         })
     }

--- a/pleco/src/bots/alphabeta.rs
+++ b/pleco/src/bots/alphabeta.rs
@@ -1,19 +1,19 @@
 //! The alpha-beta algorithm.
 use board::*;
 use core::piece_move::*;
-use core::score::*;
+use super::*;
 
 #[allow(unused_imports)]
 use test::Bencher;
 #[allow(unused_imports)]
 use test;
 
-use super::{BestMove,eval_board};
+use super::{ScoringMove, eval_board};
 
 
 const MAX_PLY: u16 = 5;
 
-pub fn alpha_beta_search(board: &mut Board, mut alpha: i32, beta: i32, max_depth: u16) -> BestMove {
+pub fn alpha_beta_search(board: &mut Board, mut alpha: i16, beta: i16, max_depth: u16) -> ScoringMove {
 
     if board.depth() == max_depth {
         return eval_board(board);
@@ -23,30 +23,31 @@ pub fn alpha_beta_search(board: &mut Board, mut alpha: i32, beta: i32, max_depth
 
     if moves.is_empty() {
         if board.in_check() {
-            return BestMove::new_none(MATE + board.depth() as i32);
+            return ScoringMove::blank(-MATE_V + board.depth() as i16);
         } else {
-            return BestMove::new_none(DRAW);
+            return ScoringMove::blank(DRAW_V);
         }
     }
-    let mut best_move: Option<BitMove> = None;
+
+    let mut best_move: BitMove = BitMove::null();
     for mov in moves {
         board.apply_move(mov);
         let return_move = alpha_beta_search(board, -beta, -alpha, max_depth).negate();
         board.undo_move();
         if return_move.score > alpha {
             alpha = return_move.score;
-            best_move = Some(mov);
+            best_move = mov;
         }
         if alpha >= beta {
-            return BestMove {
-                best_move: Some(mov),
+            return ScoringMove {
+                bit_move: mov,
                 score: alpha,
             };
         }
     }
 
-    BestMove {
-        best_move: best_move,
+    ScoringMove {
+        bit_move: best_move,
         score: alpha,
     }
 }

--- a/pleco/src/bots/alphabeta.rs
+++ b/pleco/src/bots/alphabeta.rs
@@ -1,53 +1,40 @@
 //! The alpha-beta algorithm.
 use board::*;
-use core::piece_move::*;
 use super::*;
-
-#[allow(unused_imports)]
-use test::Bencher;
-#[allow(unused_imports)]
-use test;
 
 use super::{ScoringMove, eval_board};
 
 
 const MAX_PLY: u16 = 5;
 
-pub fn alpha_beta_search(board: &mut Board, mut alpha: i16, beta: i16, max_depth: u16) -> ScoringMove {
-
-    if board.depth() == max_depth {
+pub fn alpha_beta_search(board: &mut Board, mut alpha: i16, beta: i16, depth: u16) -> ScoringMove {
+    if depth == 0 {
         return eval_board(board);
     }
 
-    let moves = board.generate_moves();
+    let mut moves = board.generate_scoring_moves();
 
     if moves.is_empty() {
         if board.in_check() {
-            return ScoringMove::blank(-MATE_V + board.depth() as i16);
+            return ScoringMove::blank(-MATE_V);
         } else {
             return ScoringMove::blank(DRAW_V);
         }
     }
 
-    let mut best_move: BitMove = BitMove::null();
-    for mov in moves {
-        board.apply_move(mov);
-        let return_move = alpha_beta_search(board, -beta, -alpha, max_depth).negate();
+    let mut best_move = ScoringMove::blank(alpha);
+    for mov in moves.iter_mut() {
+        board.apply_move(mov.bit_move);
+        mov.score = -alpha_beta_search(board, -beta, -alpha, depth - 1).score;
         board.undo_move();
-        if return_move.score > alpha {
-            alpha = return_move.score;
-            best_move = mov;
-        }
-        if alpha >= beta {
-            return ScoringMove {
-                bit_move: mov,
-                score: alpha,
-            };
+        if mov.score > alpha {
+            alpha = mov.score;
+            if alpha >= beta {
+                return *mov;
+            }
+            best_move = *mov;
         }
     }
 
-    ScoringMove {
-        bit_move: best_move,
-        score: alpha,
-    }
+    best_move
 }

--- a/pleco/src/bots/jamboree.rs
+++ b/pleco/src/bots/jamboree.rs
@@ -1,173 +1,80 @@
 //! The jamboree algorithm.
 use board::*;
-use core::piece_move::*;
 use super::*;
+use super::{ScoringMove};
+use super::alphabeta::alpha_beta_search;
 use rayon;
-
-#[allow(unused_imports)]
-use test::Bencher;
-#[allow(unused_imports)]
-use test;
 
 const DIVIDE_CUTOFF: usize = 5;
 const DIVISOR_SEQ: usize = 4;
 
-// depth: depth from given
-// half_moves: total moves
-
 pub fn jamboree(board: &mut Board, mut alpha: i16, beta: i16,
-                max_depth: u16, plys_seq: u16) -> ScoringMove
-{
+                depth: u16, plys_seq: u16) -> ScoringMove {
     assert!(alpha <= beta);
-    if board.depth() >= max_depth {
-        return eval_board(board);
+    if depth <= 2 {
+        return alpha_beta_search(board, alpha, beta, depth);
     }
 
-    if board.depth() >= max_depth - plys_seq {
-        return alpha_beta_search(board, alpha, beta, max_depth);
-    }
+    let mut moves = board.generate_scoring_moves();
 
-    let moves = board.generate_moves();
     if moves.is_empty() {
         if board.in_check() {
-            return ScoringMove::blank(-MATE_V + board.depth() as i16);
+            return ScoringMove::blank(-MATE_V);
         } else {
             return ScoringMove::blank(DRAW_V);
         }
     }
 
-    let amount_seq: usize = 1 + (moves.len() / DIVIDE_CUTOFF) as usize;
-    let (seq, non_seq) = moves.split_at(amount_seq);
+    let amount_seq: usize = 1 + (moves.len() / DIVISOR_SEQ).min(2) as usize;
+    let (seq, non_seq) = moves.split_at_mut(amount_seq);
 
-    let mut best_move: BitMove = BitMove::null();
-    let mut best_value: i16 = NEG_INF_V;
+    let mut best_move: ScoringMove = ScoringMove::blank(alpha);
+
     for mov in seq {
-        board.apply_move(*mov);
-        let return_move = jamboree(board, -beta, -alpha, max_depth, plys_seq).negate();
+        board.apply_move(mov.bit_move);
+        mov.score  = -jamboree(board, -beta, -alpha, depth - 1, plys_seq).score;
         board.undo_move();
 
-
-        if return_move.score > best_value {
-            best_move = *mov;
-            best_value = return_move.score;
-
-            if return_move.score > alpha {
-                alpha = return_move.score;
-                best_move = *mov;
-            }
-
+        if mov.score > alpha {
+            alpha = mov.score;
             if alpha >= beta {
-                return ScoringMove {
-                    bit_move: *mov,
-                    score: alpha,
-                };
+                return *mov;
             }
+            best_move = *mov;
         }
     }
 
-    let returned_move = parallel_task(non_seq, board, alpha, beta, max_depth, plys_seq);
-
-    if returned_move.score > alpha {
-        returned_move
-    } else {
-        ScoringMove {
-            bit_move: best_move,
-            score: best_value,
-        }
-    }
+    parallel_task(non_seq, board, alpha, beta, depth, plys_seq).max(best_move)
 }
 
-fn parallel_task(
-    slice: &[BitMove],
-    board: &mut Board,
-    mut alpha: i16,
-    beta: i16,
-    max_depth: u16,
-    plys_seq: u16,
-) -> ScoringMove {
-    let mut best_move: BitMove = BitMove::null();
-    if slice.len() <= DIVIDE_CUTOFF {
-        for mov in slice {
-            board.apply_move(*mov);
-            let return_move = jamboree(board, -beta, -alpha, max_depth, plys_seq).negate();
-            board.undo_move();
 
-            if return_move.score > alpha {
-                alpha = return_move.score;
+fn parallel_task(slice: &mut [ScoringMove], board: &mut Board, mut alpha: i16,
+                 beta: i16, depth: u16, plys_seq: u16, ) -> ScoringMove {
+
+    if slice.len() <= DIVIDE_CUTOFF {
+        let mut best_move: ScoringMove = ScoringMove::blank(alpha);
+        for mov in slice {
+            board.apply_move(mov.bit_move);
+            mov.score = -jamboree(board, -beta, -alpha, depth - 1, plys_seq).score;
+            board.undo_move();
+            if mov.score > alpha {
+                alpha = mov.score;
+                if alpha >= beta {
+                    return *mov;
+                }
                 best_move = *mov;
             }
-
-            if alpha >= beta {
-                return ScoringMove {
-                    bit_move: *mov,
-                    score: alpha,
-                };
-            }
         }
-
+        best_move
     } else {
         let mid_point = slice.len() / 2;
-        let (left, right) = slice.split_at(mid_point);
+        let (left, right) = slice.split_at_mut(mid_point);
         let mut left_clone = board.parallel_clone();
 
-        let (left_move, right_move) = rayon::join (
-            || parallel_task(left, &mut left_clone, alpha, beta, max_depth, plys_seq),
-            || parallel_task(right, board, alpha, beta, max_depth, plys_seq));
+        let (left_move, right_move): (ScoringMove, ScoringMove) = rayon::join (
+            || parallel_task(left, &mut left_clone, alpha, beta, depth, plys_seq),
+            || parallel_task(right, board, alpha, beta, depth, plys_seq));
 
-        if left_move.score > alpha {
-            alpha = left_move.score;
-            best_move = left_move.bit_move;
-        }
-        if right_move.score > alpha {
-            alpha = right_move.score;
-            best_move = right_move.bit_move;
-        }
-    }
-    ScoringMove {
-        bit_move: best_move,
-        score: alpha,
-    }
-
-}
-
-
-
-fn alpha_beta_search(board: &mut Board, mut alpha: i16, beta: i16, max_depth: u16) -> ScoringMove {
-    if board.depth() == max_depth {
-        return eval_board(board);
-    }
-
-    let moves = board.generate_moves();
-
-    if moves.is_empty() {
-        if board.in_check() {
-            return ScoringMove::blank(-MATE_V + (board.depth() as i16));
-        } else {
-            return ScoringMove::blank(DRAW_V);
-        }
-    }
-
-    let mut best_move: BitMove = BitMove::null();
-    for mov in moves {
-        board.apply_move(mov);
-        let return_move = alpha_beta_search(board, -beta, -alpha, max_depth).negate();
-        board.undo_move();
-
-        if return_move.score > alpha {
-            alpha = return_move.score;
-            best_move = mov;
-        }
-
-        if alpha >= beta {
-            return ScoringMove {
-                bit_move: mov,
-                score: alpha,
-            };
-        }
-    }
-
-    ScoringMove {
-        bit_move: best_move,
-        score: alpha,
+        left_move.max(right_move)
     }
 }

--- a/pleco/src/bots/minimax.rs
+++ b/pleco/src/bots/minimax.rs
@@ -2,51 +2,15 @@
 use board::*;
 use super::*;
 
-#[allow(unused_imports)]
-use test::Bencher;
-#[allow(unused_imports)]
-use test;
-
-use std::cmp::max;
-
-// depth: depth from given
-// half_moves: total moves
-
-pub fn minimax(board: &mut Board, max_depth: u16) -> ScoringMove {
-    if board.depth() >= max_depth {
-        return eval_board(board);
-    }
-
-    let moves = board.generate_moves();
-    if moves.is_empty() {
-        if board.in_check() {
-            return ScoringMove::blank(-MATE_V + (board.depth() as i16));
-        } else {
-            return ScoringMove::blank(DRAW_V);
-        }
-    }
-    let mut best_move = ScoringMove::blank(NEG_INF_V);
-    for mov in moves {
-        board.apply_move(mov);
-        let returned_move: ScoringMove = minimax(board, max_depth)
-            .negate()
-            .swap_move(mov);
-
-        board.undo_move();
-        best_move = max(returned_move, best_move);
-    }
-    best_move
-}
-
-pub fn minimax2(board: &mut Board, max_depth: u16) -> ScoringMove {
-    if board.depth() >= max_depth {
+pub fn minimax(board: &mut Board, depth: u16) -> ScoringMove {
+    if depth == 0 {
         return eval_board(board);
     }
 
     let moves = board.generate_scoring_moves();
     if moves.is_empty() {
         if board.in_check() {
-            return ScoringMove::blank(-MATE_V + (board.depth() as i16));
+            return ScoringMove::blank(-MATE_V);
         } else {
             return ScoringMove::blank(DRAW_V);
         }
@@ -55,21 +19,9 @@ pub fn minimax2(board: &mut Board, max_depth: u16) -> ScoringMove {
     moves.into_iter()
         .map(|mut m: ScoringMove| {
             board.apply_move(m.bit_move);
-            m.score = -minimax2(board, max_depth - 1).score;
+            m.score = minimax(board, depth - 1).negate().score;
             board.undo_move();
             m
         }).max()
         .unwrap()
-
-//    let mut best_move = ScoringMove::blank(NEG_INF_V);
-//    for mov in moves {
-//        board.apply_move(mov);
-//        let returned_move: ScoringMove = minimax(board, max_depth)
-//            .negate()
-//            .swap_move(mov);
-//
-//        board.undo_move();
-//        best_move = max(returned_move, best_move);
-//    }
-//    best_move
 }

--- a/pleco/src/bots/minimax.rs
+++ b/pleco/src/bots/minimax.rs
@@ -19,7 +19,7 @@ pub fn minimax(board: &mut Board, depth: u16) -> ScoringMove {
     moves.into_iter()
         .map(|mut m: ScoringMove| {
             board.apply_move(m.bit_move);
-            m.score = minimax(board, depth - 1).negate().score;
+            m.score = -minimax(board, depth - 1).score;
             board.undo_move();
             m
         }).max()

--- a/pleco/src/bots/mod.rs
+++ b/pleco/src/bots/mod.rs
@@ -11,15 +11,18 @@ pub mod alphabeta;
 pub mod jamboree;
 pub mod iterative_parallel_mvv_lva;
 
-use core::piece_move::BitMove;
+use core::piece_move::*;
 use tools::{Searcher,UCILimit};
 use board::Board;
 use tools::eval::*;
 use core::score::*;
 
-use std::cmp::{Ordering,PartialEq,PartialOrd,Ord};
 
 const MAX_PLY: u16 = 4;
+const MATE_V: i16 = MATE as i16;
+const DRAW_V: i16 = DRAW as i16;
+const NEG_INF_V: i16 = NEG_INFINITE as i16;
+const INF_V: i16 = INFINITE as i16;
 
 /// Searcher that randomly chooses a move. The fastest, yet dumbest, searcher we have to offer.
 pub struct RandomBot {}
@@ -55,11 +58,10 @@ impl Searcher for AlphaBetaSearcher {
 
     fn best_move(board: Board, limit: UCILimit) -> BitMove {
         let max_depth = if limit.is_depth() {limit.depth_limit()} else {MAX_PLY};
-        let alpha = NEG_INFINITE;
-        let beta = INFINITE;
+        let alpha = NEG_INF_V;
+        let beta = INF_V;
         alphabeta::alpha_beta_search(&mut board.shallow_clone(), alpha, beta, max_depth)
-            .best_move
-            .unwrap()
+            .bit_move
     }
 }
 
@@ -81,11 +83,10 @@ impl Searcher for JamboreeSearcher {
 
     fn best_move(board: Board, limit: UCILimit) -> BitMove {
         let max_depth = if limit.is_depth() {limit.depth_limit()} else {MAX_PLY};
-        let alpha = NEG_INFINITE;
-        let beta = INFINITE;
+        let alpha = NEG_INF_V;
+        let beta = INF_V;
         jamboree::jamboree(&mut board.shallow_clone(), alpha, beta, max_depth, 2)
-            .best_move
-            .unwrap()
+            .bit_move
     }
 }
 
@@ -96,7 +97,7 @@ impl Searcher for MiniMaxSearcher {
 
     fn best_move(board: Board, limit: UCILimit) -> BitMove {
         let max_depth = if limit.is_depth() {limit.depth_limit()} else {MAX_PLY};
-        minimax::minimax( &mut board.shallow_clone(),  max_depth).best_move.unwrap()
+        minimax::minimax( &mut board.shallow_clone(),  max_depth).bit_move
     }
 }
 
@@ -109,62 +110,13 @@ impl Searcher for ParallelMiniMaxSearcher {
     fn best_move(board: Board, limit: UCILimit) -> BitMove {
         let max_depth = if limit.is_depth() {limit.depth_limit()} else {MAX_PLY};
         parallel_minimax::parallel_minimax(&mut board.shallow_clone(),  max_depth)
-            .best_move
-            .unwrap()
+            .bit_move
     }
 }
-
-/// Used by the Searchers to keep track of a move's strength.
-#[derive(Eq, Copy, Clone)]
-pub struct BestMove {
-    best_move: Option<BitMove>,
-    score: Value,
-}
-
-impl BestMove {
-    #[inline(always)]
-    pub fn new_none(score: Value) -> Self {
-        BestMove {
-            best_move: None,
-            score: score,
-        }
-    }
-
-    #[inline(always)]
-    pub fn negate(mut self) -> Self {
-        self.score = self.score.wrapping_neg();
-        self
-    }
-
-    #[inline(always)]
-    pub fn swap_move(mut self, bitmove: BitMove) -> Self {
-        self.best_move = Some(bitmove);
-        self
-    }
-}
-
-impl Ord for BestMove {
-    fn cmp(&self, other: &BestMove) -> Ordering {
-        self.score.cmp(&other.score)
-    }
-}
-
-impl PartialOrd for BestMove {
-    fn partial_cmp(&self, other: &BestMove) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for BestMove {
-    fn eq(&self, other: &BestMove) -> bool {
-        self.score == other.score
-    }
-}
-
 
 #[doc(hidden)]
-pub fn eval_board(board: &Board) -> BestMove {
-    BestMove::new_none(Eval::eval_low(board))
+pub fn eval_board(board: &Board) -> ScoringMove {
+    ScoringMove::blank(Eval::eval_low(board) as i16)
 }
 
 

--- a/pleco/src/bots/mod.rs
+++ b/pleco/src/bots/mod.rs
@@ -24,6 +24,11 @@ const DRAW_V: i16 = DRAW as i16;
 const NEG_INF_V: i16 = NEG_INFINITE as i16;
 const INF_V: i16 = INFINITE as i16;
 
+
+struct BoardWrapper<'a> {
+    b: &'a mut Board
+}
+
 /// Searcher that randomly chooses a move. The fastest, yet dumbest, searcher we have to offer.
 pub struct RandomBot {}
 

--- a/pleco/src/bots/parallel_minimax.rs
+++ b/pleco/src/bots/parallel_minimax.rs
@@ -2,96 +2,35 @@
 use board::*;
 use core::piece_move::*;
 use super::*;
+use bots::minimax::minimax;
 
+use rayon::prelude::*;
 
-//use rayon::prelude::*;
+use mucow::MuCow;
 
-use rayon;
-
-use std::cmp::max;
-#[allow(unused_imports)]
-use test::Bencher;
-#[allow(unused_imports)]
-use test;
-
-
-const MAX_PLY: u16 = 5;
-const DIVIDE_CUTOFF: usize = 8;
-
-// depth: depth from given
-// half_moves: total moves
-
-pub fn parallel_minimax(board: &mut Board, max_depth: u16) -> ScoringMove {
-    if board.depth() >= max_depth {
-        return eval_board(board);
+pub fn parallel_minimax(board: &mut Board, depth: u16) -> ScoringMove {
+    if depth <= 2 {
+        return minimax(board, depth);
     }
 
-    let moves = board.generate_moves();
+    let mut moves = board.generate_scoring_moves();
     if moves.is_empty() {
         if board.in_check() {
-            ScoringMove::blank(-MATE_V + (board.depth() as i16))
+            return ScoringMove::blank(-MATE_V);
         } else {
-            ScoringMove::blank(DRAW_V)
+            return ScoringMove::blank(DRAW_V);
         }
-    } else {
-        parallel_task(&moves, board, max_depth)
     }
-}
-//
-//fn parallel_task2(board: Board, depth: u16) -> i16 {
-//    board.generate_moves()
-//        .as_mut_slice()
-//        .par_iter_mut()
+    let board_wr: MuCow<Board> = MuCow::Borrowed(board);
+    moves.as_mut_slice()
+        .par_iter_mut()
 //        .with_max_len(6)
-//        .map_with(board, |b: &mut Board, m: ScoringMove | {
-//            b.apply_move(m.bit_move);
-//            m.score = parallel_task2(b, depth - 1);
-//            b.undo_move();
-//            m.score
-//        }).max().unwrap()
-//}
-
-
-//fn minimax_evaluate(board: &mut ChessBoard, depth: u16) -> i16 {
-//    if depth == 0 {
-//        return board.evaluate_strength();
-//    }
-//
-//    board.generate_moves()
-//         .as_mut_slice()
-//         .par_iter_mut()
-//         .map_with(board, |b: &mut ChessBoard, m: ChessMove | {
-//             b.apply_move(*m);
-//             let score = -parallel_task2(b, depth - 1);
-//             b.undo_move();
-//             score
-//         }).max()
-//        .unwrap()
-//}
-
-fn parallel_task(slice: &[BitMove], board: &mut Board, max_depth: u16) -> ScoringMove {
-    if board.depth() == max_depth - 2 || slice.len() <= DIVIDE_CUTOFF {
-        let mut best_move = ScoringMove::blank(NEG_INF_V);
-
-        for mov in slice {
-            board.apply_move(*mov);
-            let returned_move: ScoringMove = parallel_minimax(board, max_depth)
-                .negate()
-                .swap_move(*mov);
-            board.undo_move();
-            best_move = max(returned_move, best_move);
-        }
-        best_move
-    } else {
-        let mid_point = slice.len() / 2;
-        let (left, right) = slice.split_at(mid_point);
-        let mut left_clone = board.parallel_clone();
-
-        let (left_move, right_move) = rayon::join(
-            || parallel_task(left, &mut left_clone, max_depth),
-            || parallel_task(right, board, max_depth),
-        );
-
-        max(left_move,right_move)
-    }
+        .map_with(board_wr, |b: &mut MuCow<Board>, m: &mut ScoringMove | {
+            b.apply_move(m.bit_move);
+            m.score = parallel_minimax(&mut *b, depth - 1).negate().score;
+            b.undo_move();
+            m
+        }).max()
+        .unwrap()
+        .clone()
 }

--- a/pleco/src/bots/parallel_minimax.rs
+++ b/pleco/src/bots/parallel_minimax.rs
@@ -1,12 +1,11 @@
 //! The parallel minimax algorithm.
+use rayon::prelude::*;
+use mucow::MuCow;
+
 use board::*;
 use core::piece_move::*;
 use super::*;
 use bots::minimax::minimax;
-
-use rayon::prelude::*;
-
-use mucow::MuCow;
 
 pub fn parallel_minimax(board: &mut Board, depth: u16) -> ScoringMove {
     if depth <= 2 {
@@ -22,15 +21,13 @@ pub fn parallel_minimax(board: &mut Board, depth: u16) -> ScoringMove {
         }
     }
     let board_wr: MuCow<Board> = MuCow::Borrowed(board);
-    moves.as_mut_slice()
+    *moves.as_mut_slice()
         .par_iter_mut()
-//        .with_max_len(6)
         .map_with(board_wr, |b: &mut MuCow<Board>, m: &mut ScoringMove | {
             b.apply_move(m.bit_move);
-            m.score = parallel_minimax(&mut *b, depth - 1).negate().score;
+            m.score = -parallel_minimax(&mut *b, depth - 1).score;
             b.undo_move();
             m
         }).max()
         .unwrap()
-        .clone()
 }

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -66,7 +66,6 @@ use std::cmp::{Ordering,PartialEq,PartialOrd,Ord};
 
 use super::*;
 use super::sq::SQ;
-use super::mono_traits::{PieceTrait};
 
 // Castles have the src as the king bit and the dst as the rook
 const SRC_MASK: u16 = 0b0000_000000_111111;

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -66,6 +66,7 @@ use std::cmp::{Ordering,PartialEq,PartialOrd,Ord};
 
 use super::*;
 use super::sq::SQ;
+use super::mono_traits::{PieceTrait};
 
 // Castles have the src as the king bit and the dst as the rook
 const SRC_MASK: u16 = 0b0000_000000_111111;
@@ -151,6 +152,17 @@ impl BitMove {
     pub const FLAG_DOUBLE_PAWN: u16 = 1;
     pub const FLAG_CAPTURE: u16 = 4;
     pub const FLAG_EP: u16 = 5;
+
+    pub const FLAG_PROMO_N: u16 = 0b1000;
+    pub const FLAG_PROMO_B: u16 = 0b1001;
+    pub const FLAG_PROMO_R: u16 = 0b1010;
+    pub const FLAG_PROMO_Q: u16 = 0b1011;
+
+    pub const FLAG_PROMO_CAP_N: u16 = 0b1100;
+    pub const FLAG_PROMO_CAP_B: u16 = 0b1101;
+    pub const FLAG_PROMO_CAP_R: u16 = 0b1110;
+    pub const FLAG_PROMO_CAP_Q: u16 = 0b1111;
+
     /// Creates a new BitMove from raw bits.
     ///
     /// # Safety
@@ -174,15 +186,21 @@ impl BitMove {
         BitMove::make(BitMove::FLAG_DOUBLE_PAWN,src,dst)
     }
 
-    /// Makes a non-enpassant `BitMove` from a source and destination square.
+    /// Makes a non-enpassant capturing `BitMove` from a source and destination square.
     #[inline(always)]
     pub const fn make_capture(src: SQ, dst: SQ) -> BitMove {
         BitMove::make(BitMove::FLAG_CAPTURE,src,dst)
     }
 
+    /// Makes an enpassant `BitMove` from a source and destination square.
+    #[inline(always)]
+    pub const fn make_ep_capture(src: SQ, dst: SQ) -> BitMove {
+        BitMove::make(BitMove::FLAG_EP,src,dst)
+    }
+
     /// Creates a `BitMove` from a source and destination square, as well as the current
     /// flag.
-    #[inline]
+    #[inline(always)]
     pub const fn make(flag_bits: u16, src: SQ, dst: SQ) -> BitMove {
         BitMove { data: (flag_bits << 12) | src.0 as u16 | ((dst.0 as u16) << 6) }
     }

--- a/pleco/src/helper/magic.rs
+++ b/pleco/src/helper/magic.rs
@@ -9,8 +9,6 @@ use core::{rank_bb,file_bb};
 use core::bit_twiddles::popcount64;
 use tools::prng::PRNG;
 
-
-
 /// Size of the magic rook table.
 const ROOK_M_SIZE: usize = 102_400;
 static mut ROOK_MAGICS: [SMagic; 64] = [SMagic::init(); 64];
@@ -43,7 +41,9 @@ pub fn bishop_attacks(mut occupied: u64, square: u8) -> u64 {
     occupied &= magic_entry.mask;
     occupied = occupied.wrapping_mul(magic_entry.magic);
     occupied = occupied.wrapping_shr(magic_entry.shift);
-    unsafe { *(mem::transmute::<usize, *const u64>(magic_entry.ptr)).add(occupied as usize) }
+    unsafe {
+        *(magic_entry.ptr as *const u64).add(occupied as usize)
+    }
 }
 
 #[inline]
@@ -52,7 +52,9 @@ pub fn rook_attacks(mut occupied: u64, square: u8) -> u64 {
     occupied &= magic_entry.mask;
     occupied = occupied.wrapping_mul(magic_entry.magic);
     occupied = occupied.wrapping_shr(magic_entry.shift);
-    unsafe { *(mem::transmute::<usize, *const u64>(magic_entry.ptr)).add(occupied as usize) }
+    unsafe {
+        *(magic_entry.ptr as *const u64).add(occupied as usize)
+    }
 }
 
 

--- a/pleco/src/helper/mod.rs
+++ b/pleco/src/helper/mod.rs
@@ -30,6 +30,11 @@ unsafe impl Send for Helper {}
 
 unsafe impl Sync for Helper {}
 
+impl Default for Helper {
+    fn default() -> Self {
+        Helper::new()
+    }
+}
 
 impl Helper {
     pub fn new() -> Self {

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -98,6 +98,7 @@ extern crate num_cpus;
 extern crate rand;
 extern crate rayon;
 extern crate prefetch;
+extern crate mucow;
 extern crate test;
 
 pub mod core;

--- a/pleco/src/tools/pleco_arc.rs
+++ b/pleco/src/tools/pleco_arc.rs
@@ -65,7 +65,7 @@ impl<T> Arc<T> {
     pub fn new(data: T) -> Self {
         let x = Box::new(ArcInner {
             count: atomic::AtomicUsize::new(1),
-            data: data,
+            data,
         });
         unsafe {
             Arc { p: NonNull::new_unchecked(Box::into_raw(x)) }

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -162,7 +162,7 @@ impl Entry {
     /// Returns the value of the node in respect to the depth searched && when it was placed into the TranspositionTable.
     pub fn time_value(&self, curr_time: u8) -> i16 {
         let inner: i16 = ((259i16).wrapping_add(curr_time as i16)).wrapping_sub(self.time_node_bound.data as i16) & 0b1111_1100;
-        i16::from((self.depth as i16).wrapping_sub(inner).wrapping_mul(2))
+        (self.depth as i16).wrapping_sub(inner).wrapping_mul(2)
     }
 }
 

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -68,7 +68,7 @@ doctest = true
 
 [dependencies]
 pleco = { path = "../pleco", version = "0.3.8" }
-clippy = {version = "0.0.179", optional = true}
+clippy = {version = "0.0.187", optional = true}
 chrono = "0.4.0"
 rand = "0.4.2"
 rayon = "1.0.0"

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -74,6 +74,7 @@ rand = "0.4.2"
 rayon = "1.0.0"
 num_cpus = "1.8.0"
 crossbeam-utils = "0.2.2"
+generic-array = "0.10.0"
 
 [dependencies.lazy_static]
 version = "1.0.0"

--- a/pleco_engine/benches/depth_benches.rs
+++ b/pleco_engine/benches/depth_benches.rs
@@ -65,3 +65,17 @@ fn engine_6_ply(b: &mut Bencher) {
         black_box(s.await_move());
     })
 }
+
+
+#[bench]
+fn engine_7_ply(b: &mut Bencher) {
+    let mut limit = PreLimits::blank();
+    limit.depth = Some(7);
+    let board = Board::default();
+    let mut s = PlecoSearcher::init(false);
+    b.iter(|| {
+        black_box(s.clear_tt());
+        black_box(s.search(&board, &limit));
+        black_box(s.await_move());
+    })
+}

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -90,6 +90,7 @@ impl PlecoSearcher {
 
     pub fn clear_search(&mut self) {
         self.clear_tt();
+        threadpool().clear_all();
     }
 
     fn uci_go(&mut self, args: &[&str]) {
@@ -167,7 +168,6 @@ impl PlecoSearcher {
     }
 
     pub fn search(&mut self, board: &Board, limit: &PreLimits) {
-        TT_TABLE.new_search();
         self.search_mode = SearchType::Search;
         threadpool().uci_search(board, &(limit.clone().create()));
 

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -46,6 +46,7 @@ extern crate rand;
 extern crate pleco;
 extern crate chrono;
 extern crate crossbeam_utils;
+extern crate generic_array;
 
 pub mod threadpool;
 pub mod sync;

--- a/pleco_engine/src/root_moves/mod.rs
+++ b/pleco_engine/src/root_moves/mod.rs
@@ -8,8 +8,9 @@ use std::cmp::Ordering as CmpOrder;
 use pleco::core::score::*;
 use pleco::BitMove;
 
-const MAX_MOVES: usize = 255;
+const MAX_MOVES: usize = 256;
 
+/// Keeps track of information of a move for the position to be searched.
 #[derive(Copy, Clone,Eq)]
 pub struct RootMove {
     pub score: i32,
@@ -20,6 +21,7 @@ pub struct RootMove {
 
 
 impl RootMove {
+    /// Creates a new `RootMove`.
     #[inline]
     pub fn new(bit_move: BitMove) -> Self {
         RootMove {
@@ -30,6 +32,8 @@ impl RootMove {
         }
     }
 
+    /// Places the current score into the previous_score field, and then updates
+    /// the score and depth.
     #[inline]
     pub fn rollback_insert(&mut self, score: i32, depth: u16) {
         self.prev_score = self.score;
@@ -37,12 +41,14 @@ impl RootMove {
         self.depth_reached = depth;
     }
 
+    /// Inserts a score and depth.
     #[inline]
     pub fn insert(&mut self, score: i32, depth: u16) {
         self.score = score;
         self.depth_reached = depth;
     }
 
+    /// Places the current score in the previous score.
     #[inline]
     pub fn rollback(&mut self) {
         self.prev_score = self.score;

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -120,11 +120,13 @@ impl RootMoveList {
         }
     }
 
+    /// Converts to a `MoveList`.
     pub fn to_list(&self) -> MoveList {
         let vec =  self.iter().map(|m| m.bit_move).collect::<Vec<BitMove>>();
         MoveList::from(vec)
     }
 
+    /// Returns the previous best score.
     #[inline]
     pub fn prev_best_score(&self) -> i32 {
         unsafe {

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -33,6 +33,7 @@ unsafe impl Send for RootMoveList {}
 unsafe impl Sync for RootMoveList {}
 
 impl RootMoveList {
+    /// Creates an empty `RootMoveList`.
     #[inline]
     pub fn new() -> Self {
         unsafe {
@@ -43,11 +44,13 @@ impl RootMoveList {
         }
     }
 
+    /// Returns the length of the list.
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.len.load(Ordering::SeqCst)
     }
 
+    /// Replaces the current `RootMoveList` with another `RootMoveList`.
     pub fn clone_from_other(&mut self, other: &RootMoveList) {
         self.len.store(other.len(), Ordering::SeqCst);
         unsafe {
@@ -57,6 +60,7 @@ impl RootMoveList {
         }
     }
 
+    /// Replaces the current `RootMoveList` with the moves inside a `MoveList`.
     pub fn replace(&mut self, moves: &MoveList) {
         self.len.store(moves.len(), Ordering::SeqCst);
         for (i, mov) in moves.iter().enumerate() {
@@ -64,12 +68,18 @@ impl RootMoveList {
         }
     }
 
+    /// Applies `RootMove::rollback()` to each `RootMove` inside.
     #[inline]
     pub fn rollback(&mut self) {
         self.iter_mut()
             .for_each(|b| b.prev_score = b.score);
     }
 
+    /// Returns the first `RootMove` in the list.
+    ///
+    /// # Safety
+    ///
+    /// May return a nonsense `RootMove` if the list hasn't been initalized since the start.
     #[inline]
     pub fn first(&mut self) -> &mut RootMove {
         unsafe {
@@ -77,8 +87,9 @@ impl RootMoveList {
         }
     }
 
+    /// Applied a `Most Valuable Victim - Leave Valuable Attacker` sort to the list.
     #[inline]
-    pub fn mvv_laa_sort(&mut self, board: &Board) {
+    pub fn mvv_lva_sort(&mut self, board: &Board) {
         self.sort_by_key(|root_move| {
             let a = root_move.bit_move;
             let piece = board.piece_at_sq((a).get_src()).unwrap();
@@ -99,10 +110,11 @@ impl RootMoveList {
         });
     }
 
+    /// Shuffles the moves arounf.
     #[inline]
     pub fn shuffle(&mut self, thread_id: usize, board: &Board) {
         if thread_id == 0 || thread_id >= 20 {
-            self.mvv_laa_sort(board);
+            self.mvv_lva_sort(board);
         } else {
             rand::thread_rng().shuffle(self.as_mut());
         }

--- a/pleco_engine/src/search/movepick.rs
+++ b/pleco_engine/src/search/movepick.rs
@@ -8,11 +8,46 @@ use pleco::core::move_list::ScoringMoveList;
 // TODO: use Generators once stabilized.
 
 // types
-//
-// All
+
+// Root
+// MainSearch
 // Evasions
 // ProbCut
 // Qsearch
+
+
+// Strategy
+
+// RootMoves -------
+
+// MainSearch ------
+// Captures_init
+// Good_Captures
+// Killer0
+// Killer1
+// CounterMove
+// Quiet_Init
+// Quiet
+// Bad Captures
+//
+
+// Evasions -------
+// Evasions_init
+// All_evasions
+
+// ProbCut
+// Probcut_Captures_Init
+// Probvut Captures
+
+// Qsearch
+// QCaptures_Init
+// QCaptures
+// QChecks
+// QSearch_Recaptures
+// QRecaptures
+
+
+
 
 pub struct MovePicker {
 

--- a/pleco_engine/src/search/movepick.rs
+++ b/pleco_engine/src/search/movepick.rs
@@ -1,6 +1,7 @@
 
 #[allow(unused_imports)]
 use pleco::{BitMove,Board};
+#[allow(unused_imports)]
 use pleco::core::move_list::ScoringMoveList;
 
 

--- a/pleco_engine/src/search/movepick.rs
+++ b/pleco_engine/src/search/movepick.rs
@@ -1,0 +1,18 @@
+
+#[allow(unused_imports)]
+use pleco::{BitMove,Board};
+use pleco::core::move_list::ScoringMoveList;
+
+
+// TODO: use Generators once stabilized.
+
+// types
+//
+// All
+// Evasions
+// ProbCut
+// Qsearch
+
+pub struct MovePicker {
+
+}

--- a/pleco_engine/src/tables/mod.rs
+++ b/pleco_engine/src/tables/mod.rs
@@ -5,6 +5,41 @@ pub mod material;
 use std::ptr::NonNull;
 use std::heap::{Alloc, Layout, Heap};
 
+
+// TODO: Create StatBoards using const FNs
+// TODO: Create 3DBoard using Const fns
+
+pub trait StatBoardType<T: Sized> {
+    fn size1() -> usize;
+    fn size2() -> usize;
+    const SIZE1: usize;
+    const SIZE2: usize;
+}
+
+//
+//pub struct StatBoards<T, SBT: StatBoardType<T>> {
+//    a: NonNull<T>,
+//    p: PhantomData<SBT>
+//}
+//
+//impl<T> StatBoardType<T> {
+//    pub fn new() -> Self {
+//
+//    }
+//
+//    fn alloc<T, SBT: StatBoardType<T>>() -> NonNull<T> {
+//        unsafe {
+//            let size = SBT::SIZE1 * SBT::SIZE2;
+//            let ptr = Heap.alloc_zeroed(Layout::array::<T>(size).unwrap());
+//            let new_ptr = match ptr {
+//                Ok(ptr) => ptr,
+//                Err(err) => Heap.oom(err),
+//            };
+//            NonNull::new(new_ptr as *mut T).unwrap()
+//        }
+//    }
+//}
+
 // TODO: Performance increase awaiting with const generics: https://github.com/rust-lang/rust/issues/44580
 
 /// Generic Heap-stored array of entries. Used for building more specific abstractions.
@@ -104,7 +139,6 @@ impl<T: Sized> Drop for TableBase<T> {
         }
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -235,6 +235,13 @@ impl ThreadPool {
         }
     }
 
+    pub fn clear_all(&mut self) {
+        for thread_ptr in self.threads.iter_mut() {
+            let mut thread: &mut Searcher = unsafe { &mut **(*thread_ptr).get() };
+            thread.clear();
+        }
+    }
+
     /// Starts a UCI search. The result will be printed to stdout if the stdout setting
     /// is true.
     pub fn uci_search(&mut self, board: &Board, limits: &Limits) {

--- a/pleco_engine/src/time/time_management.rs
+++ b/pleco_engine/src/time/time_management.rs
@@ -11,13 +11,13 @@ use std::f64;
 
 
 const MOVE_HORIZON: i64 = 50;
-const MAX_RATIO: f64 = 7.01;
+const MAX_RATIO: f64 = 5.31;
 const STEAL_RATIO: f64 = 0.35;
 
 // TODO: These should be made into UCIOptions
 const MIN_THINKING_TIME: i64 = 20;
 const MOVE_OVERHEAD: i64 = 30;
-const SLOW_MOVER: i64 = 89;
+const SLOW_MOVER: i64 = 50;
 
 #[derive(PartialEq)]
 enum TimeCalc {
@@ -81,7 +81,7 @@ impl TimeManager {
             hyp_my_time = hyp_my_time.max(0);
 
             let t1: i64 = MIN_THINKING_TIME + TimeManager::remaining(hyp_my_time, hyp_mtg, ply as i64, SLOW_MOVER, TimeCalc::Ideal);
-            let t2: i64 = MIN_THINKING_TIME + TimeManager::remaining(hyp_my_time, hyp_mtg, ply as i64, SLOW_MOVER, TimeCalc::Max);
+            let t2: i64 = MIN_THINKING_TIME + TimeManager::remaining(hyp_my_time, hyp_mtg, ply as i64, SLOW_MOVER - 5, TimeCalc::Max);
 
             ideal_time = t1.min(ideal_time);
             max_time = t2.min(max_time);


### PR DESCRIPTION
`pleco` changes:
- Changed `ScoringBitMove` to `ScoringMove`.
- Added `Board::generate_scoring_moves()`.
- Modified the bots to be more Rusty and concise. 
- Slight MoveGeneration optimization.
- Added `Board::empty()` for checking if a square is empty
- Added `Board::pseudo_legal_move()` for checking if a move is pseudo-legal.


`pleco_engine` changes
- Better qsearch
- More Documentation
- Better TimeManagement, specifically returning earlier / later from a search than the ideal time for stable bestMoves.
- Added Thread clearing
