### PR TITLE
Move Generation Fixes, Fen Parsing fixes, and BoardState Refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ os:
   - linux
 
 script:
-  - cargo bench
   - cargo build --verbose
   - cargo test --verbose
+  - cargo bench
 #  - cd pleco/ && cargo bench
 #  - cd ../pleco_engine/ && cargo bench --bench eval_benches
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Setting up a board position is extremely simple.
 ```rust
 use pleco::{Board,Player,PieceType};
 
-let board = Board::default();
+let board = Board::start_pos();
 assert_eq!(board.count_piece(Player::White,PieceType::P), 8);
 assert_eq!(&board.fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
 ```
@@ -87,7 +87,7 @@ position for the current player.
 ```rust
 use pleco::{Board,BitMove};
 
-let mut board = Board::default(); // create a board of the starting position
+let mut board = Board::start_pos(); // create a board of the starting position
 let moves = board.generate_moves(); // generate all possible legal moves
 board.apply_move(moves[0]);
 assert_eq!(board.moves_played(), 1);
@@ -99,7 +99,7 @@ UCI Move, in the format [src_sq][dst_sq][promo]. E.g., moving a piece from A1 to
 while promoting a pawn would look something like "e7e81". If the board is supplied a UCI move that is either 
 incorrectly formatted or illegal, false shall be returned.
 ```rust
-let mut board = Board::default(); // create a board of the starting position
+let mut board = Board::start_pos(); // create a board of the starting position
 let success = board.apply_uci_move("e7e8q"); // apply a move where piece on e7 -> eq, promotes to queen
 assert!(!success); // Wrong, not a valid move for the starting position
 ```
@@ -107,7 +107,7 @@ assert!(!success); // Wrong, not a valid move for the starting position
 #### Undoing Moves
 We can revert to the previous chessboard state with a simple Board::undo_move()
 ```rust
-let mut board = Board::default();
+let mut board = Board::start_pos();
 board.apply_uci_move("e2e4"); // A very good starting move, might I say
 assert_eq!(board.moves_played(),1);
 board.undo_move();

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -5,7 +5,7 @@ use pleco::core::piece_move::BitMove;
 
 
 fn main() {
-    let mut board = Board::default(); // create a board of the starting position
+    let mut board = Board::start_pos(); // create a board of the starting position
     let moves: Vec<BitMove> = board.generate_moves(); // generate all possible legal moves
     board.apply_move(moves[0]);
     assert_eq!(board.moves_played(), 1);

--- a/pleco/README.md
+++ b/pleco/README.md
@@ -42,7 +42,7 @@ Setting up a board position is extremely simple.
 ```rust
 use pleco::{Board,Player,PieceType};
 
-let board = Board::default();
+let board = Board::start_pos();
 assert_eq!(board.count_piece(Player::White,PieceType::P), 8);
 assert_eq!(&board.fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
 ```
@@ -64,7 +64,7 @@ position for the current player.
 ```rust
 use pleco::{Board,BitMove};
 
-let mut board = Board::default(); // create a board of the starting position
+let mut board = Board::start_pos(); // create a board of the starting position
 let moves = board.generate_moves(); // generate all possible legal moves
 board.apply_move(moves[0]);
 assert_eq!(board.moves_played(), 1);
@@ -76,7 +76,7 @@ while promoting a pawn would look something like "e7e81". If the board is suppli
 incorrectly formatted or illegal, false shall be returned.
 
 ```rust
-let mut board = Board::default(); // create a board of the starting position
+let mut board = Board::start_pos(); // create a board of the starting position
 let success = board.apply_uci_move("e7e8q"); // apply a move where piece on e7 -> eq, promotes to queen
 assert!(!success); // Wrong, not a valid move for the starting position
 ```
@@ -86,7 +86,7 @@ assert!(!success); // Wrong, not a valid move for the starting position
 We can revert to the previous chessboard state with a simple `Board::undo_move()`:
 
 ```rust
-let mut board = Board::default();
+let mut board = Board::start_pos();
 board.apply_uci_move("e2e4"); // A very good starting move, might I say
 assert_eq!(board.moves_played(),1);
 board.undo_move();

--- a/pleco/benches/board_benches.rs
+++ b/pleco/benches/board_benches.rs
@@ -26,7 +26,7 @@ lazy_static! {
 
 fn bench_board_100_clone(c: &mut Criterion) {
     lazy_static::initialize(&RAND_BOARDS);
-    c.bench_function(" bench_board_100_clone", |b|
+    c.bench_function("Board Clone 100", |b|
     b.iter(|| {
         for board in RAND_BOARDS.iter() {
             black_box(board.shallow_clone());
@@ -37,7 +37,7 @@ fn bench_board_100_clone(c: &mut Criterion) {
 
 
 fn bench_find(c: &mut Criterion) {
-    c.bench_function("bench_find", |b| {
+    c.bench_function("Board find King SQ", |b| {
         lazy_static::initialize(&RAND_BOARDS);
         b.iter(|| {
             black_box({
@@ -50,7 +50,7 @@ fn bench_find(c: &mut Criterion) {
 }
 
 fn bench_apply_100_move(c: &mut Criterion) {
-    c.bench_function("bench_apply_100_move",  |b| {
+    c.bench_function("Board Apply 100 Move",  |b| {
         let mut prng = PRNG::init(SEED);
         let mut board_move: Vec<(Board, BitMove)> = Vec::with_capacity(100);
 
@@ -72,7 +72,7 @@ fn bench_apply_100_move(c: &mut Criterion) {
 }
 
 fn bench_undo_100_move(c: &mut Criterion) {
-    c.bench_function("bench_undo_100_move", |b| {
+    c.bench_function("Board Undo 100 Move", |b| {
         let mut boards: Vec<Board> = Vec::with_capacity(100);
         for board in RAND_BOARDS.iter() {
             boards.push(board.parallel_clone());

--- a/pleco/benches/bot_benches.rs
+++ b/pleco/benches/bot_benches.rs
@@ -11,7 +11,7 @@ use pleco::tools::Searcher;
 lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         let mut vec = Vec::new();
-        vec.push(Board::default());
+        vec.push(Board::start_pos());
         vec
     };
 }

--- a/pleco/benches/move_gen_benches.rs
+++ b/pleco/benches/move_gen_benches.rs
@@ -45,11 +45,11 @@ fn all_movegen(c: &mut Criterion) {
     let nochk_quietchecks_legal = Fun::new("MoveGen QuietChecks - Legal", movegen_ty::<Legal, QuietChecksGenType>);
     let nochk_quietchecks_pslegal = Fun::new("MoveGen QuietChecks - PseudoLegal", movegen_ty::<PseudoLegal, QuietChecksGenType>);
 
-    let chk_legal = Fun::new("MoveGen Evasions - Legal", movegen_ty::<Legal, AllGenType>);
-    let chk_pslegal = Fun::new("MoveGen Evasions - PseudoLegal", movegen_ty::<PseudoLegal, AllGenType>);
+//    let chk_legal = Fun::new("MoveGen Evasions - Legal", movegen_ty::<Legal, AllGenType>);
+//    let chk_pslegal = Fun::new("MoveGen Evasions - PseudoLegal", movegen_ty::<PseudoLegal, AllGenType>);
 
-//    let chk_legal = Fun::new("MoveGen Evasions - Legal", movegen_ty::<Legal, EvasionsGenType>);
-//    let chk_pslegal = Fun::new("MoveGen Evasions - PseudoLegal", movegen_ty::<PseudoLegal, EvasionsGenType>);
+    let chk_legal = Fun::new("MoveGen Evasions - Legal", movegen_ty::<Legal, EvasionsGenType>);
+    let chk_pslegal = Fun::new("MoveGen Evasions - PseudoLegal", movegen_ty::<PseudoLegal, EvasionsGenType>);
 
     let all_funcs = vec![all_legal, all_pslegal];
 

--- a/pleco/benches/perft_benches.rs
+++ b/pleco/benches/perft_benches.rs
@@ -27,7 +27,7 @@ fn perft_all(c: &mut Criterion) {
         .collect();
 
     let perft_3_f = Fun::new("Perft 3",perft_3);
-    let perft_4_f = Fun::new("Perft 3",perft_4);
+    let perft_4_f = Fun::new("Perft 4",perft_4);
 
     let funs = vec![perft_3_f, perft_4_f];
 

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -526,7 +526,13 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             if self.board.ep_square() != NO_SQ {
                 let ep_sq: SQ = self.board.ep_square();
                 assert_eq!(ep_sq.rank(), P::player().relative_rank(Rank::R6));
-                if G::gen_type() != GenTypes::Evasions || (target & P::down(ep_sq).to_bb()).is_not_empty() {
+
+                // An en passant capture can be an evasion only if the checking piece
+                // is the double pushed pawn and so is in the target. Otherwise this
+                // is a discovery check and we are forced to do otherwise.
+                if G::gen_type() != GenTypes::Evasions
+                    || (target & P::down(ep_sq).to_bb()).is_not_empty() {
+
                     left_cap = pawns_not_rank_7 & pawn_attacks_from(ep_sq, P::opp_player());
 
                     while let Some(src) = left_cap.pop_some_lsb() {
@@ -633,7 +639,7 @@ mod tests {
 
     #[test]
     fn movelist_basic() {
-        let b = Board::default();
+        let b = Board::start_pos();
         let mut m = b.generate_moves();
         let mut i = 0;
         for _d in m.iter() {
@@ -654,7 +660,7 @@ mod tests {
 
     #[test]
     fn movegen_list_sim_basic() {
-        let b = Board::default();
+        let b = Board::start_pos();
         let mb = b.generate_moves();
         let ms = MoveGen::generate_scoring::<Legal, AllGenType>(&b);
         assert_eq!(mb.len(), ms.len());

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn start_pos_perft() {
-        let b: Board = Board::default();
+        let b: Board = Board::start_pos();
         assert_eq!(1, perft(&b,0));
         assert_eq!(20, perft(&b,1));
         assert_eq!(400, perft(&b,2));
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn start_pos_perft_all() {
-        let b: Board = Board::default();
+        let b: Board = Board::start_pos();
         perft_all(&b,3)
             .check(8902, 34, 0, 0, 0, 12, 0);
         perft_all(&b,4)
@@ -151,7 +151,6 @@ mod tests {
             .check(4_865_609, 82_719, 258, 0, 0, 27351, 347);
     }
 
-    #[ignore]
     #[test]
     fn perft_kiwipete() {
         let b: Board = Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -").unwrap();
@@ -162,16 +161,18 @@ mod tests {
         assert_eq!(193690690, perft(&b,5));
     }
 
+    // THis passes, but we're gonna ignore it as it takes a long time to use.
     #[ignore]
     #[test]
     fn perft_kiwipete_all() {
         let b: Board = Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -").unwrap();
        perft_all(&b,3)
-           .check(97862, 17102, 45, 0, 993, 1, 3162);
+           .check(97862, 17102, 45, 3162, 0, 993, 1);
         perft_all(&b,4)
-            .check(4085603, 757163, 1929, 15172, 25523, 43, 128013);
+            .check(4085603, 757163, 1929, 128013, 15172, 25523, 43);
         perft_all(&b,5)
-            .check(193690690, 35043416, 73365, 8392, 3309887, 30171, 4993637);
+            .check(193690690, 35043416, 73365, 4993637, 8392, 3309887, 30171);
+
     }
 
     #[test]
@@ -202,4 +203,5 @@ mod tests {
         assert_eq!(89_890, perft(&b,3));
         assert_eq!(3_894_594, perft(&b,4));
     }
+
 }

--- a/pleco/src/bots/mod.rs
+++ b/pleco/src/bots/mod.rs
@@ -133,14 +133,14 @@ mod tests {
 
     #[test]
     fn minimax_equality() {
-        let b = Board::default();
+        let b = Board::start_pos();
         let b2 = b.shallow_clone();
         assert_eq!(MiniMaxSearcher::best_move(b, 5), ParallelMiniMaxSearcher::best_move(b2, 5));
     }
 
     #[test]
     fn alpha_equality() {
-        let b = Board::default();
+        let b = Board::start_pos();
         let b2 = b.shallow_clone();
         assert_eq!(AlphaBetaSearcher::best_move(b, 5), JamboreeSearcher::best_move(b2, 5));
     }

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ```ignore
 //! use pleco::Board;
-//! let board = Board::default();
+//! let board = Board::start_pos();
 //! ```
 //!
 //! Generating a list of moves (Contained inside a [`MoveList`]) can be done with:
@@ -35,7 +35,7 @@
 //! Applying and undoing moves is simple:
 //!
 //! ```ignore
-//! let mut board = Board::default();
+//! let mut board = Board::start_pos();
 //! let list = board.generate_moves();
 //!
 //! for mov in list.iter() {

--- a/pleco/tests/board_build.rs
+++ b/pleco/tests/board_build.rs
@@ -10,7 +10,7 @@ use pleco::*;
 
 #[test]
 fn test_init_counts() {
-    let board = Board::default();
+    let board = Board::start_pos();
     assert_eq!(board.count_piece(Player::White, PieceType::P), 8);
     assert_eq!(board.count_piece(Player::White, PieceType::N), 2);
     assert_eq!(board.count_piece(Player::White, PieceType::B), 2);
@@ -33,7 +33,7 @@ fn test_init_counts() {
 
 #[test]
 fn basic_move_apply() {
-    let mut b = Board::default();
+    let mut b = Board::start_pos();
     let p1 = PreMoveInfo {
         src: SQ(12),
         dst: SQ(28),
@@ -65,7 +65,7 @@ fn basic_move_apply() {
 
 #[test]
 fn move_seq_1() {
-    let mut b = board::Board::default();
+    let mut b = board::Board::start_pos();
     let p = PreMoveInfo {
         src: SQ(12),
         dst: SQ(28),

--- a/pleco/tests/board_move_apply.rs
+++ b/pleco/tests/board_move_apply.rs
@@ -8,7 +8,7 @@ use std::*;
 
 #[test]
 fn random_moves() {
-    let mut chess_board = Board::default();
+    let mut chess_board = Board::start_pos();
     let mut moves = chess_board.generate_moves();
     let mut i = 0;
     while i < 50 && !moves.is_empty() {

--- a/pleco/tests/move_generating.rs
+++ b/pleco/tests/move_generating.rs
@@ -8,14 +8,8 @@ use pleco::board::{Board,RandBoard};
 
 #[test]
 fn test_movegen_captures() {
-    let mut vec = Vec::new();
-    for _i in 0..10 {
-        let mut b  = RandBoard::default().one();
-        if !b.in_check() {
-            vec.push(b);
-        }
-    }
-    // TODO: Possible failures on a travis build
+    let vec =  RandBoard::default().no_check().many(9);
+
     vec.iter().for_each(|b| {
         let moves = b.generate_moves_of_type(GenTypes::Captures);
         for m in moves {
@@ -29,22 +23,13 @@ fn test_movegen_captures() {
 
 #[test]
 fn test_movegen_quiets() {
-    let mut vec = Vec::new();
-    for _i in 0..10 {
-        let mut b = RandBoard::default().one();
-        if !b.in_check() {
-            vec.push(b);
-        }
-    }
+    let vec =  RandBoard::default().no_check().many(6);
+
     vec.iter().for_each(|b| {
         let moves = b.generate_moves_of_type(GenTypes::Quiets);
         for m in moves {
             if !m.is_promo() && !m.is_castle() {
                 assert!(!m.is_capture());
-//                if b.captured_piece(m).is_some() {
-//                    b.pretty_print();
-//                    println!("{}",m.to_string());
-//                }
                 assert!(b.captured_piece(m).is_none());
             }
         }
@@ -53,13 +38,8 @@ fn test_movegen_quiets() {
 
 #[test]
 fn test_movegen_quiet_checks() {
-    let mut vec = Vec::new();
-    for _i in 0..10 {
-        let mut b = RandBoard::default().no_check().one();
-        if !b.in_check() {
-            vec.push(b);
-        }
-    }
+    let vec =  RandBoard::default().no_check().many(5);
+
     vec.iter().for_each(|b| {
         b.generate_moves_of_type(GenTypes::QuietChecks);
     })
@@ -84,7 +64,7 @@ fn bit_move_position() {
 
 #[test]
 fn test_opening_position() {
-    let b = Board::default();
+    let b = Board::start_pos();
     let moves = b.generate_moves();
     assert_eq!(moves.len(), (8 * 2) + (2 * 2));
 }

--- a/pleco/tests/pseudo_legal_checks.rs
+++ b/pleco/tests/pseudo_legal_checks.rs
@@ -17,7 +17,7 @@ fn pseudolegal_all_fens() {
 
 #[test]
 fn pseudolegal_rand() {
-    for _x in 0..14 {
+    for _x in 0..9 {
         let board = Board::random().one();
         pseudolegal_correctness(&board);
     }
@@ -63,7 +63,7 @@ fn legal_all_fens() {
 
 #[test]
 fn legal_rand() {
-    for _x in 0..14 {
+    for _x in 0..10 {
         let board = Board::random().one();
         legal_correctness(&board);
     }

--- a/pleco_engine/benches/multimove_benches.rs
+++ b/pleco_engine/benches/multimove_benches.rs
@@ -15,7 +15,7 @@ fn search_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
     b.iter_with_setup(|| {
         let mut s = PlecoSearcher::init(false);
         s.clear_search();
-        (Board::default(), s)
+        (Board::start_pos(), s)
     }, |(mut board, mut s)| {
         black_box(s.search(&board, &limit));
         let mov = black_box(s.await_move());

--- a/pleco_engine/benches/startpos_benches.rs
+++ b/pleco_engine/benches/startpos_benches.rs
@@ -15,7 +15,7 @@ fn search_singular_engine<D: DepthLimit>(b: &mut Bencher) {
     b.iter_with_setup(|| {
         let mut s = PlecoSearcher::init(false);
         s.clear_search();
-        (Board::default(), s)
+        (Board::start_pos(), s)
     }, |(board, mut s)| {
         black_box(s.search(&board, &limit));
         black_box(s.await_move());

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -42,7 +42,7 @@ impl PlecoSearcher {
         PlecoSearcher {
             options: OptionsMap::new(),
             search_mode: SearchType::None,
-            board: Board::default()
+            board: Board::start_pos()
         }
     }
 
@@ -235,7 +235,7 @@ mod tests {
     fn ply_3() {
         let mut limit = PreLimits::blank();
         limit.depth = Some(3);
-        let board = Board::default();
+        let board = Board::start_pos();
         let mut s = PlecoSearcher::init(false);
         s.search(&board, &limit);
         s.await_move();

--- a/pleco_engine/src/movepick/mod.rs
+++ b/pleco_engine/src/movepick/mod.rs
@@ -496,13 +496,13 @@ mod tests {
     // Testing the movepicker for the starting position
     #[test]
     fn movepick_startpos_blank() {
-        movepick_main_search(Board::default(), BitMove::null(), &[BitMove::null(); 2],
+        movepick_main_search(Board::start_pos(), BitMove::null(), &[BitMove::null(); 2],
                              BitMove::null(), 5);
     }
 
     #[test]
     fn movepick_startpos_rand_op() {
-        let b = Board::default();
+        let b = Board::start_pos();
         for _x in 0..25 {
             movepick_rand_one(b.clone());
         }
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn movepick_rand_mainsearch() {
-        for _x in 0..20 {
+        for _x in 0..15 {
             let mut b = Board::random().one();
             movepick_rand_one(b);
             println!("pass movepick rand! {} ",_x);

--- a/pleco_engine/src/search/eval.rs
+++ b/pleco_engine/src/search/eval.rs
@@ -863,7 +863,7 @@ mod tests {
 //    #[test]
 //    fn eval_stuff() {
 //        init_statics();
-//        let board = Board::default();
+//        let board = Board::start_pos();
 //        let mut score = Score::ZERO;
 //        let mut bb = board.get_occupied();
 //        while let Some(sq) = bb.pop_some_lsb() {
@@ -879,7 +879,7 @@ mod tests {
 
     #[test]
     fn trace_eval() {
-        let mut board = Board::default();
+        let mut board = Board::start_pos();
         board.pretty_print();
         Evaluation::trace(&board);
         println!("\n------------------------------\n");

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -131,7 +131,7 @@ impl Searcher {
             cond,
             depth_completed: 0,
             limit: Limits::blank(),
-            board: Board::default(),
+            board: Board::start_pos(),
             time_man: &TIMER,
             tt: &TT_TABLE,
             pawns: PawnTable::new(16384),

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn pawn_eval() {
         let mut t: PawnTable = PawnTable::new(1 << 7);
-        let boards: Vec<Board> = Board::random().pseudo_random(2222212).many(15);
+        let boards: Vec<Board> = Board::random().pseudo_random(2222212).many(9);
         let mut score: i64 = 0;
         boards.iter().for_each(|b| {
             score += t.probe(b).pawns_score().0 as i64;

--- a/pleco_engine/src/uci/parse.rs
+++ b/pleco_engine/src/uci/parse.rs
@@ -159,7 +159,7 @@ pub fn setboard_parse_board(args: &[&str]) -> Option<Board> {
 pub fn position_parse_board(args: &[&str]) -> Option<Board> {
     let start: &str = args[0];
     let mut board = if start == "startpos" {
-        Some(Board::default())
+        Some(Board::start_pos())
     } else if start == "fen" {
         let fen_string: String = args[1..].iter()
                                           .take_while(|p: &&&str| **p != "moves")


### PR DESCRIPTION
Only changed are to `pleco` here, most notable fixing the Move-Generation bug. Turns out it was a problem with validating En-passant moves with `Board::legal(m: BitMove)`

- Changed `Board::default()` to `Board::startpos()`
- Fixed slightly incorrect `MoveGen` (closes #89)
- Moved `BoardState` setting functions to it's own module.
- Fen now correctly sets all the `BoardState` fields.
