### PR TITLE
50% Search Time improvement, Node Counting, & Other Fixes

### DIFF
--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -1979,6 +1979,27 @@ impl Board {
         self.piece_at_sq(dst)
     }
 
+    /// Returns the Zobrist key after a move is played. Doesn't recognize special
+    /// moves like castling, en-passant, and promotion.
+    ///
+    /// # Safety
+    ///
+    /// Panics if the move is not legal for the current board.
+    pub fn key_after(&self, m: BitMove) -> u64 {
+        let src = m.get_src();
+        let dst = m.get_dest();
+        let (us, piece) = self.piece_locations.player_piece_at(src).unwrap();
+        let captured = self.piece_locations.player_piece_at(dst);
+
+        let mut key: u64 = self.zobrist() ^ z_side();
+
+        if let Some((them, cap)) = captured {
+            key ^= z_square(dst, them, cap);
+        }
+
+        key ^ z_square(src, us, piece) ^ z_square(dst, us, piece)
+    }
+
     /// Returns a prettified String of the current `Board`, for easy command line displaying.
     ///
     /// Capital Letters represent white pieces, while lower case represents black pieces.

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -74,7 +74,6 @@
 #![feature(integer_atomics)]
 #![feature(allocator_api)]
 #![feature(const_fn)]
-#![feature(const_indexing)]
 #![feature(pointer_methods)]
 #![feature(cfg_target_feature, target_feature)]
 #![feature(stdsimd)]

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -36,7 +36,7 @@
 use std::ptr::NonNull;
 use std::mem;
 use std::heap::{Alloc, Layout, Heap};
-use std::cmp::max;
+use std::cmp::min;
 use std::cell::UnsafeCell;
 
 use prefetch::prefetch::*;
@@ -429,7 +429,7 @@ impl TranspositionTable {
     /// Returns the % of the hash table that is full.
     pub fn hash_percent(&self) -> f64 {
         unsafe {
-            let clusters_scanned: u64 = max((*self.cap.get() - 1) as u64, 2018);
+            let clusters_scanned: u64 = min((*self.cap.get() - 1) as u64, 333);
             let mut hits: f64 = 0.0;
 
             for i in 0..clusters_scanned {
@@ -439,7 +439,7 @@ impl TranspositionTable {
                     // get a pointer to the specified entry
                     let entry_ptr: *mut Entry = init_entry.offset(e as isize);
                     let entry: &Entry = & (*entry_ptr);
-                    if !entry.is_empty() {
+                    if entry.time() == self.time_age() {
                         hits += 1.0;
                     }
                 }

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -32,7 +32,7 @@ coveralls = { repository = "sfleischman105/Pleco", branch = "master", service = 
 opt-level = 3
 debug = false
 debug-assertions = false
-panic = "unwind"
+panic = "panic"
 codegen-units = 1
 lto = true
 

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -73,7 +73,7 @@ chrono = "0.4.0"
 rand = "0.4.2"
 rayon = "1.0.0"
 num_cpus = "1.8.0"
-crossbeam-utils = "0.2.2"
+crossbeam-utils = "0.3.2"
 generic-array = "0.10.0"
 
 [dependencies.lazy_static]

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -31,7 +31,6 @@
 #![feature(allocator_api)]
 #![feature(trusted_len)]
 #![feature(fused)]
-#![feature(const_indexing)]
 #![feature(const_fn)]
 #![feature(box_into_raw_non_null)]
 

--- a/pleco_engine/src/root_moves/mod.rs
+++ b/pleco_engine/src/root_moves/mod.rs
@@ -83,6 +83,6 @@ impl PartialOrd for RootMove {
 
 impl PartialEq for RootMove {
     fn eq(&self, other: &RootMove) -> bool {
-        self.score == other.score && self.depth_reached == other.depth_reached
+        self.score == other.score && self.prev_score == other.prev_score
     }
 }

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -10,7 +10,7 @@ use std::mem;
 use rand;
 use rand::Rng;
 
-use pleco::{MoveList,Board,BitMove,SQ};
+use pleco::{Board,BitMove,SQ};
 use pleco::core::*;
 use pleco::tools::tt::*;
 use pleco::core::score::*;
@@ -206,7 +206,7 @@ impl Searcher {
         // iterate through each thread, and find the best move available (based on score)
         let mut best_move = self.root_moves().first().bit_move;
         let mut best_score = self.root_moves().first().score;
-        if let LimitsType::Depth(_) = self.limit.limits_type  {
+        if !self.limit.limits_type.is_depth()  {
             let mut best_thread: &Searcher = &self;
             threadpool().threads.iter().map(|u| unsafe {&**u.get()}).for_each(|th| {
                 let depth_diff = th.depth_completed as i32 - best_thread.depth_completed as i32;
@@ -278,7 +278,8 @@ impl Searcher {
 
         let mut time_reduction: f64 = 1.0;
         let mut stack: ThreadStack = ThreadStack::new();
-        let ss: &mut Stack = stack.ply_zero();
+
+        stack.ply_zero().ply = 0;
 
         // Shuffle (or possibly sort) the root moves so each thread searches different moves.
         self.shuffle();
@@ -296,11 +297,10 @@ impl Searcher {
             // rollback all the root moves, ala set the previous score to the current score.
             self.root_moves().rollback();
 
-            let prev_best_score = self.root_moves()[0].prev_score;
-
             // Delta gives a bound in the iterative loop before re-searching that position.
             // Only applicable for a depth of 5 and beyond.
             if depth >= 5 {
+                let prev_best_score = self.root_moves().first().score;
                 delta = 18;
                 alpha = max(prev_best_score - delta, NEG_INFINITE);
                 beta = min(prev_best_score + delta, INFINITE);
@@ -309,9 +309,9 @@ impl Searcher {
             // Loop until we find a value that is within the bounds of alpha, beta, and the delta margin.
             'aspiration_window: loop {
                 // search!
-                best_value = self.search::<PV>(alpha, beta, ss,depth);
+                best_value = self.search::<PV>(alpha, beta, stack.ply_zero(),depth);
 
-                // Order root moves by the socre retreived post search.
+                // Order root moves by the score retreived post search.
                 self.root_moves().sort();
 
                 if self.stop() {
@@ -338,14 +338,12 @@ impl Searcher {
                 assert!(beta <= INFINITE);
             }
 
+            self.root_moves().sort();
+
             // Main Thread provides an update to the GUI
             if self.use_stdout() && self.main_thread() {
-                println!("info depth {} score {} pv {}",
-                         depth,
-                         best_value,
-                         self.root_moves().first().bit_move.to_string());
+                self.pv(depth, best_value, stack.ply_zero());
             }
-
 
             if !self.stop() {
                 self.depth_completed = depth;
@@ -374,7 +372,7 @@ impl Searcher {
                 if !self.stop() {
                     let score_diff: i32 = best_value - self.previous_score;
 
-                    let improving_factor: i64 = (229).max((715).min(
+                    let improving_factor: i64 = (229).max((701).min(
                           357
                         + 119 * self.failed_low as i64
                         -   5 * score_diff as i64));
@@ -393,6 +391,8 @@ impl Searcher {
                     unstable_factor *= self.previous_time_reduction.powf(0.51) / time_reduction;
 
                     // Stop the search if we have only one legal move, or if available time elapsed
+                    let new_time = (TIMER.ideal_time() as f64 * unstable_factor as f64 * improving_factor as f64 / 602.0) as i64;
+                    println!("new time: {}", new_time);
                     if self.root_moves().len() == 1
                         || TIMER.elapsed() >= (TIMER.ideal_time() as f64 * unstable_factor as f64 * improving_factor as f64 / 602.0) as i64 {
                         threadpool().set_stop(true);
@@ -459,14 +459,14 @@ impl Searcher {
 
         // probe the transposition table
         let (tt_hit, tt_entry): (bool, &mut Entry) = TT_TABLE.probe(zob);
-        let tt_value: Value = if tt_hit {tt_entry.score as i32} else {0};
+        let tt_value: Value = if tt_hit {tt_entry.score as i32} else {NONE};
         let tt_move: BitMove = if tt_hit {tt_entry.best_move} else {BitMove::null()};
 
         // At non-PV nodes, check for a better TT value to return.
         if !is_pv
             && tt_hit
             && tt_entry.depth as i16 >= depth as i16
-            && tt_value != 0
+            && tt_value != NONE
             && correct_bound_eq(tt_value, beta, tt_entry.node_type()) {
 
             if tt_move != BitMove::null() {
@@ -480,24 +480,24 @@ impl Searcher {
 
         // Get and set the position eval
         if in_check {
-            pos_eval = 0;
+            pos_eval = NONE;
         } else {
             if tt_hit {
-                pos_eval = if tt_entry.eval == 0 {
+                pos_eval = if tt_entry.eval as i32 == NONE {
                     self.eval()
                 } else {
                     tt_entry.eval as i32
                 };
 
                 // check for tt value being a better position evaluation
-                if tt_value != 0 && correct_bound(tt_value, pos_eval, tt_entry.node_type()) {
+                if tt_value != NONE && correct_bound(tt_value, pos_eval, tt_entry.node_type()) {
                     pos_eval = tt_value;
                 }
             } else {
                 pos_eval = self.eval();
                 tt_entry.place(zob, BitMove::null(),
-                               0, pos_eval as i16,
-                               0, NodeBound::NoBound,
+                               NONE as i16, pos_eval as i16,
+                               -6, NodeBound::NoBound,
                                self.tt.time_age());
             }
 
@@ -537,6 +537,7 @@ impl Searcher {
                 } else {
                     !is_pv || moves_played > 1
                 };
+
                 if do_full_depth {
                     value = if depth <= 1 {
                         if gives_check { -self.qsearch::<NonPV,InCheck>(-(alpha+1), -alpha, ss.incr(), 0)
@@ -560,7 +561,7 @@ impl Searcher {
                 assert!(value < INFINITE );
 
                 if self.stop() {
-                    return 0;
+                    return ZERO;
                 }
 
                 if at_root {
@@ -590,6 +591,11 @@ impl Searcher {
 
                     if value > alpha {
                         best_move = mov;
+
+                        if is_pv && !at_root {
+                            ss.incr().pv = mov;
+                        }
+
                         if is_pv && value < beta {
                             alpha = value;
                         } else {
@@ -636,11 +642,11 @@ impl Searcher {
         let ply: u16 = ss.ply;
         let zob: u64 = self.board.zobrist();
         let (tt_hit, tt_entry): (bool, &mut Entry) = TT_TABLE.probe(zob);
-        let tt_value: Value = if tt_hit {tt_entry.score as i32} else {0};
+        let tt_value: Value = if tt_hit {tt_entry.score as i32} else {NONE};
 
         let mut value: Value;
-        let mut best_value: Value = NEG_INFINITE;
-        let mut pos_eval: Value = NEG_INFINITE + 1;
+        let mut best_value: Value;
+        let mut pos_eval: Value;
         let mut moves_played = 0;
         let old_alpha = alpha;
         let tt_depth: i16 = if in_check || rev_depth >= 0 {0} else {-1};
@@ -663,14 +669,17 @@ impl Searcher {
         if !is_pv
             && tt_hit
             && tt_entry.depth as i16 >= tt_depth
-            && tt_value != 0
+            && tt_value != NONE
             && correct_bound_eq(tt_value, beta, tt_entry.node_type()) {
             return tt_value;
         }
 
-        if !in_check {
+        if in_check {
+            pos_eval = NONE;
+            best_value = NEG_INFINITE;
+        } else {
             if tt_hit {
-                if tt_entry.eval == 0 {
+                if tt_entry.eval as i32 == NONE {
                     best_value = self.eval();
                     pos_eval = best_value;
                 } else {
@@ -678,7 +687,7 @@ impl Searcher {
                     pos_eval = best_value;
                 }
 
-                if tt_value != 0 && correct_bound(tt_value, best_value, tt_entry.node_type()) {
+                if tt_value != NONE && correct_bound(tt_value, best_value, tt_entry.node_type()) {
                     best_value == tt_value;
                 }
             } else {
@@ -729,6 +738,10 @@ impl Searcher {
 
                     if value > alpha {
 
+                        if is_pv {
+                            ss.incr().pv = best_move;
+                        }
+
                         if is_pv && value < beta {
                             best_move = mov;
                             alpha = value;
@@ -744,16 +757,8 @@ impl Searcher {
             mov = move_picker.next(false);
         }
 
-        if moves_played == 0 {
-            if self.board.in_check() {
-                best_value = -MATE as i32 + (ply as i32);
-            } else {
-                best_value = alpha;
-            }
-        } else if best_move != BitMove::null() {
-            if !self.board.is_capture_or_promotion(best_move) {
-                self.update_quiet_stats(best_move, ss);
-            }
+        if in_check && best_value == NEG_INFINITE {
+            return -MATE + ss.ply as i32;
         }
 
         let node_bound = if  is_pv && best_value > old_alpha {NodeBound::Exact}
@@ -853,6 +858,22 @@ impl Searcher {
             }
         });
     }
+
+    fn pv(&self, depth: u16, best_value: i32, stack: &mut Stack) {
+        let mut pvs: String = self.root_moves().first().bit_move.to_string();
+        for p in 0..depth {
+            let ss = stack.offset(p as isize);
+            let mov = ss.pv;
+            if mov == BitMove::null() {
+                break;
+            }
+            pvs.push(' ');
+            pvs += &mov.stringify();
+        }
+        println!("info depth {} score {} pv {}", depth, best_value, pvs);
+    }
+
+
 }
 
 
@@ -860,28 +881,6 @@ impl Drop for Searcher {
     fn drop(&mut self) {
         self.searching.set(false);
     }
-}
-
-fn mvv_lva_sort(moves: &mut MoveList, board: &Board) {
-    moves.sort_by_key(|a| {
-        if a.is_castle() {
-            return 1;
-        }
-
-        let piece = board.piece_at_sq((*a).get_src()).unwrap();
-
-        if a.is_capture() {
-            piece.value() - board.captured_piece(*a).unwrap().value()
-        } else if piece == PieceType::P {
-            if a.is_double_push().0 {
-                2
-            } else {
-                3
-            }
-        } else {
-            4
-        }
-    })
 }
 
 fn correct_bound_eq(tt_value: i32, beta: i32, bound: NodeBound) -> bool {
@@ -893,7 +892,7 @@ fn correct_bound_eq(tt_value: i32, beta: i32, bound: NodeBound) -> bool {
 }
 
 fn correct_bound(tt_value: i32, val: i32, bound: NodeBound) -> bool {
-    if tt_value as i32 > val {
+    if tt_value as i32 >= val {
         bound as u8 & NodeBound::LowerBound as u8 != 0
     } else {
         bound as u8 & NodeBound::UpperBound as u8 != 0

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -259,8 +259,6 @@ impl Searcher {
             return;
         }
 
-        self.nodes.fetch_add(1, Ordering::Relaxed);
-
         // notify GUI that this thread is starting
         if self.use_stdout() {
             println!("info id {} start", self.id);
@@ -673,8 +671,6 @@ impl Searcher {
         assert!(is_pv || (alpha == beta - 1));
         assert_eq!(in_check, self.board.in_check());
 
-        self.nodes.fetch_add(1, Ordering::Relaxed);
-
         let ply: u16 = ss.ply;
         let zob: u64 = self.board.zobrist();
         let (tt_hit, tt_entry): (bool, &mut Entry) = TT_TABLE.probe(zob);
@@ -826,7 +822,6 @@ impl Searcher {
     }
 
     pub fn eval(&mut self) -> Value {
-        self.nodes.fetch_add(1, Ordering::Relaxed);
         let pawns = &mut self.pawns;
         let material = &mut self.material;
         eval::Evaluation::evaluate(&self.board, pawns, material)

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -642,6 +642,10 @@ impl Searcher {
             } else {
                 return DRAW as i32;
             }
+        } else if best_move != BitMove::null() {
+            if !self.board.is_capture_or_promotion(best_move) {
+                self.update_quiet_stats(best_move, ss);
+            }
         }
 
         let node_bound = if best_value as i32 >= beta {NodeBound::LowerBound}

--- a/pleco_engine/src/tables/butterfly.rs
+++ b/pleco_engine/src/tables/butterfly.rs
@@ -1,0 +1,18 @@
+
+use pleco::core::masks::*;
+
+use super::{StatBoard, NumStatBoard};
+
+/// ButterflyBoards are 2 tables (one for each color) indexed by the move's from
+/// and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
+pub struct ButterflyHistory {
+    a: [[i16; (SQ_CNT * SQ_CNT)]; PLAYER_CNT]
+}
+
+impl StatBoard<i16> for ButterflyHistory {
+    const FILL: i16 = 0;
+}
+
+impl NumStatBoard for ButterflyHistory {
+    const D: i16 = 324;
+}

--- a/pleco_engine/src/tables/capture_piece_history.rs
+++ b/pleco_engine/src/tables/capture_piece_history.rs
@@ -1,0 +1,18 @@
+use pleco::core::masks::*;
+
+use super::{StatBoard,NumStatCube};
+
+/// CapturePieceToBoards are addressed by a move's[player][piece][to][captured piece] information
+pub struct CapturePieceToHistory {
+    a: [[[[i16; PIECE_TYPE_CNT]; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
+}
+
+
+impl StatBoard<i16> for CapturePieceToHistory {
+    const FILL: i16 = 0;
+}
+
+impl NumStatCube for CapturePieceToHistory {
+    const D: i16 = 324;
+    const W: i16 = 2;
+}

--- a/pleco_engine/src/tables/continuation.rs
+++ b/pleco_engine/src/tables/continuation.rs
@@ -1,0 +1,35 @@
+use std::mem;
+
+use pleco::core::masks::*;
+use super::{StatBoard,NumStatBoard};
+
+/// PieceToBoards are addressed by a move's [player][piece][to] information
+pub struct PieceToHistory {
+    a: [[[i16; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
+}
+
+impl StatBoard<i16> for PieceToHistory {
+    const FILL: i16 = 0;
+}
+
+impl NumStatBoard for PieceToHistory {
+    const D: i16 = 936;
+}
+
+
+/// ContinuationHistory is the history of a given pair of moves, usually the
+/// current one given a previous one. History table is based on PieceToBoards
+/// instead of ButterflyBoards.
+pub struct ContinuationHistory {
+    a: [[[PieceToHistory; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
+}
+
+impl ContinuationHistory {
+    pub fn new() -> Self {
+        unsafe {mem::zeroed()}
+    }
+
+    pub fn clear(&mut self) {
+        *self = unsafe {mem::zeroed()};
+    }
+}

--- a/pleco_engine/src/tables/counter_move.rs
+++ b/pleco_engine/src/tables/counter_move.rs
@@ -1,0 +1,11 @@
+use pleco::core::masks::*;
+use pleco::{BitMove};
+use super::StatBoard;
+
+/// PieceToBoards are addressed by a move's [player][piece][square] information
+pub struct CounterMoveHistory {
+    a: [[[BitMove; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
+}
+impl StatBoard<BitMove> for CounterMoveHistory {
+    const FILL: BitMove = BitMove::null();
+}

--- a/pleco_engine/src/time/time_management.rs
+++ b/pleco_engine/src/time/time_management.rs
@@ -61,6 +61,13 @@ impl TimeManager {
         }
     }
 
+    pub fn start_timer(&self, start: Instant) {
+        unsafe {
+            let self_start = self.start.get();
+            *self_start = start;
+        }
+    }
+
     pub fn init(&self, start: Instant, timer: &UCITimer, turn: Player, ply: u16) {
         let moves_to_go: i64 = timer.moves_to_go as i64;
         let my_time: i64 = (timer.time_msec[turn as usize]) as i64;

--- a/pleco_engine/src/time/uci_timer.rs
+++ b/pleco_engine/src/time/uci_timer.rs
@@ -14,6 +14,15 @@ pub enum LimitsType {
     Ponder   // ponder mode
 }
 
+impl LimitsType {
+    pub fn is_depth(&self) -> bool {
+        match *self {
+            LimitsType::Depth(_x) => true,
+            _ => false
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct UCITimer {
     pub time_msec: [i64; PLAYER_CNT], // time each player has remaining
@@ -34,8 +43,7 @@ impl UCITimer {
         self.time_msec[0] == 0 &&
             self.time_msec[1] == 0 &&
             self.inc_msec[0] == 0 &&
-            self.inc_msec[1] == 0 &&
-            self.moves_to_go == 0
+            self.inc_msec[1] == 0
     }
 
     pub fn display(&self) {


### PR DESCRIPTION
`pleco` changes:
- Introduced `Board::key_after` for quick lookup of TT keys after a move.
- Fixed the `TranspositionTable::hash_percent()` method to only count moves searched in the current depth.

`pleco_engine` changes
- Fixed `RootMove` ordering to not take into account the depth of the move found.
- Added the StatBoards to the `Searcher` struct.
- Global limit now set by the `threadpool`, rather than the main thread.
- Added node counting.
- Printing PV info now includes additional fields like nodes, tt hash percent, and nodes / sec
- Added checks for `Value::None` on tt lookup, where the entry was found but the scores are unset.
- Added another location at the end of `search` to update the quiet stats.
- qsearch no longer updates quiet statistics, as by definition it doesn't search quiet moves.

Currently gives a search improvement of around 50%, see [prev BetaBrance](https://travis-ci.org/sfleischman105/Pleco/builds/353714116) -> [current BetaBranch](https://travis-ci.org/sfleischman105/Pleco/builds/354115902?utm_source=github_status&utm_medium=notification)

Also, appveyor [x86_64-pc-windows-gnu, nightly](https://ci.appveyor.com/project/sfleischman105/pleco/build/job/08ufjg1jani5utl4) seems to be failing due to [rust-lang/#49044](https://github.com/rust-lang/rust/issues/49044). This PR will probably still fail that test, but that won't be considered as it's a bug in rustc.