### PR TITLE
Static Exchange Evaluation + Time Management Improvements.

### DIFF
--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -1517,6 +1517,14 @@ impl Board {
         self.piece_locations.player_at(s)
     }
 
+
+    /// Returns the player and piece at a square, if any.
+    #[inline(always)]
+    pub fn player_piece_at_sq(&self, s: SQ) -> Option<(Player, PieceType)> {
+        debug_assert!(s.is_okay());
+        self.piece_locations.player_piece_at(s)
+    }
+
     /// Returns the square of the King for a given player.
     ///
     /// # Examples

--- a/pleco/src/core/bit_twiddles.rs
+++ b/pleco/src/core/bit_twiddles.rs
@@ -227,7 +227,7 @@ pub fn string_u64(input: u64) -> String {
     let mut s = String::new();
     let format_in = format_u64(input);
     for x in 0..8 {
-        let slice = &format_in[x * 8..(x * 8) + 8];
+        let slice = &format_in[x * 8..((x * 8) + 8)];
         s += slice;
         s += "\n";
     }

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -199,6 +199,7 @@ pub enum PieceType {
 }
 
 impl PieceType {
+
     /// Returns the relative value of a piece.
     ///
     /// Used for sorting moves.
@@ -238,7 +239,6 @@ impl PieceType {
             PieceType::K => 'K',
         }
     }
-
 }
 
 impl fmt::Display for PieceType {

--- a/pleco/src/core/mono_traits.rs
+++ b/pleco/src/core/mono_traits.rs
@@ -300,6 +300,25 @@ pub trait PieceTrait {
     fn piece_type() -> PieceType;
 }
 
+// Returns the next `PieceTrait` for the PieceTrait.
+//
+// Pawn   -> KnightType
+// Knight -> BishopType
+// Bishop -> RookType
+// Rook   -> QueenType
+// Queen  -> KingType
+// King   -> KingType
+//pub(crate) fn incr_pt<P: PieceTrait>(p: P) -> impl PieceTrait {
+//    match <P as PieceTrait>::piece_type() {
+//        PieceType::P => PawnType{},
+//        PieceType::N => KnightType{},
+//        PieceType::B => BishopType{},
+//        PieceType::R => QueenType{},
+//        PieceType::Q => KingType{},
+//        PieceType::K => KingType{},
+//    }
+//}
+
 /// Dummy type to represent a `Piece::P` which implements `PieceTrait`.
 pub struct PawnType {}
 /// Dummy type to represent a `Piece::N` which implements `PieceTrait`.
@@ -320,10 +339,24 @@ impl PieceTrait for PawnType {
     }
 }
 
+impl PawnType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        KnightType{}
+    }
+}
+
 impl PieceTrait for KnightType {
     #[inline(always)]
     fn piece_type() -> PieceType {
         PieceType::N
+    }
+}
+
+impl KnightType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        BishopType{}
     }
 }
 
@@ -334,10 +367,24 @@ impl PieceTrait for BishopType {
     }
 }
 
+impl BishopType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        RookType{}
+    }
+}
+
 impl PieceTrait for RookType {
     #[inline(always)]
     fn piece_type() -> PieceType {
         PieceType::R
+    }
+}
+
+impl RookType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        QueenType{}
     }
 }
 
@@ -348,9 +395,23 @@ impl PieceTrait for QueenType {
     }
 }
 
+impl QueenType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        KingType{}
+    }
+}
+
 impl PieceTrait for KingType {
     #[inline(always)]
     fn piece_type() -> PieceType {
         PieceType::K
+    }
+}
+
+impl KingType {
+    #[inline(always)]
+    fn incr() -> impl PieceTrait {
+        KingType{}
     }
 }

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -70,6 +70,7 @@ use super::sq::SQ;
 // Castles have the src as the king bit and the dst as the rook
 const SRC_MASK: u16 = 0b0000_000000_111111;
 const DST_MASK: u16 = 0b0000_111111_000000;
+const FROM_TO_MASK: u16 = 0b0000_111111_111111;
 const PR_MASK: u16 = 0b1000_000000_000000;
 const CP_MASK: u16 = 0b0100_000000_000000;
 const FLAG_MASK: u16 = 0b1111_000000_000000;
@@ -443,10 +444,23 @@ impl BitMove {
         ((self.flag()) & 0b1110) == 0b0110
     }
 
-    // Returns the 4 bit flag of the `BitMove`.
+    /// Returns the 4 bit flag of the `BitMove`.
     #[inline(always)]
     pub const fn flag(&self) -> u16 {
         self.data >> 12
+    }
+
+    /// Returns if the move is within bounds, ala the to and from squares
+    /// are not equal.
+    #[inline(always)]
+    pub const fn is_okay(&self) -> bool {
+        self.get_dest_u8() != self.get_src_u8()
+    }
+
+    /// Returns only from "from" and "to" squares of the move.
+    #[inline(always)]
+    pub const fn from_to(&self) -> u16 {
+        self.data & FROM_TO_MASK
     }
 }
 

--- a/pleco/src/core/score.rs
+++ b/pleco/src/core/score.rs
@@ -38,6 +38,8 @@ pub const QUEEN_EG: Value = 2646;
 pub const MID_GAME_LIMIT: Value = 15258;
 pub const END_GAME_LIMIT: Value = 3915;
 
+pub const MATE_IN_MAX_PLY: Value = MATE - 2 * 128;
+pub const MATED_IN_MAX_PLY: Value = -MATE + 2 * 128;
 
 /// Struct to define the value of a mid-game / end-game evaluation.
 #[derive(Copy, Clone,PartialEq,Debug)]

--- a/pleco/src/helper/prelude.rs
+++ b/pleco/src/helper/prelude.rs
@@ -228,3 +228,16 @@ pub fn psq(piece: PieceType, player: Player, sq: SQ) -> Score {
 pub fn piece_value(piece: PieceType, eg: bool) -> Value {
     psqt::piece_value(piece, eg)
 }
+
+/// Returns the value of a piece for a player. If `eg` is true, it returns the end game value. Otherwise,
+/// it'll return the midgame value.
+///
+/// If the piece is `None`, returns zero
+#[inline(always)]
+pub fn piece_value_op(op_piece: Option<PieceType>, eg: bool) -> Value {
+    if let Some(piece) = op_piece {
+        psqt::piece_value(piece, eg)
+    } else {
+        0
+    }
+}

--- a/pleco/src/helper/psqt.rs
+++ b/pleco/src/helper/psqt.rs
@@ -74,7 +74,7 @@ static PIECE_VALUE: [[Value; PHASE_CNT]; PIECE_TYPE_CNT] =
     [ BISHOP_MG,  BISHOP_EG],// White Bishop
     [ ROOK_MG,    ROOK_EG],  // White Rook
     [ QUEEN_MG,   QUEEN_MG], // White Queen
-    [ NONE,       NONE]];    // White King
+    [ ZERO,       ZERO]];    // White King
 
 #[cold]
 pub fn init_psqt() {

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -77,7 +77,7 @@
 #![feature(pointer_methods)]
 #![feature(cfg_target_feature, target_feature)]
 #![feature(stdsimd)]
-
+#![feature(conservative_impl_trait)]
 
 #![allow(dead_code)]
 

--- a/pleco_engine/benches/startpos_benches.rs
+++ b/pleco_engine/benches/startpos_benches.rs
@@ -35,7 +35,7 @@ fn bench_engine_evaluations(c: &mut Criterion) {
 
 criterion_group!(name = search_singular;
      config = Criterion::default()
-        .sample_size(18)
+        .sample_size(23)
         .warm_up_time(Duration::from_millis(100));
     targets = bench_engine_evaluations
 );

--- a/pleco_engine/src/tables/continuation.rs
+++ b/pleco_engine/src/tables/continuation.rs
@@ -33,3 +33,15 @@ impl ContinuationHistory {
         *self = unsafe {mem::zeroed()};
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    #[test]
+    fn size() {
+        println!("{}", mem::size_of::<ContinuationHistory>());
+    }
+}

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -26,6 +26,9 @@ pub static mut THREADPOOL: NonNull<ThreadPool> = unsafe {NonNull::new_unchecked(
 
 static THREADPOOL_INIT: Once = ONCE_INIT;
 
+const KILOBYTE: usize = 1000;
+const THREAD_STACK_SIZE: usize = 4000 * KILOBYTE;
+
 pub fn init_threadpool() {
     THREADPOOL_INIT.call_once(|| {
         unsafe {
@@ -41,7 +44,7 @@ pub fn init_threadpool() {
     });
 }
 
-/// Returns access to the global thread pool.z
+/// Returns access to the global thread pool
 pub fn threadpool() -> &'static mut ThreadPool {
     unsafe {
         THREADPOOL.as_mut()
@@ -108,7 +111,8 @@ impl ThreadPool {
          unsafe {
              let thread_ptr: SearcherPtr = self.create_thread();
              let builder = thread::Builder::new()
-                 .name(self.size().to_string());
+                 .name(self.size().to_string())
+                 .stack_size(THREAD_STACK_SIZE);
 
              let handle = scoped::builder_spawn_unsafe(builder,
                 move || {

--- a/pleco_engine/src/time/time_management.rs
+++ b/pleco_engine/src/time/time_management.rs
@@ -11,13 +11,13 @@ use std::f64;
 
 
 const MOVE_HORIZON: i64 = 50;
-const MAX_RATIO: f64 = 5.31;
-const STEAL_RATIO: f64 = 0.35;
+const MAX_RATIO: f64 = 5.10;
+const STEAL_RATIO: f64 = 0.32;
 
 // TODO: These should be made into UCIOptions
 const MIN_THINKING_TIME: i64 = 20;
-const MOVE_OVERHEAD: i64 = 30;
-const SLOW_MOVER: i64 = 50;
+const MOVE_OVERHEAD: i64 = 105;
+const SLOW_MOVER: i64 = 30;
 
 #[derive(PartialEq)]
 enum TimeCalc {
@@ -120,9 +120,9 @@ impl TimeManager {
     }
 
     fn move_importance(ply: i64) -> f64 {
-        const X_SCALE: f64 = 7.64;
-        const X_SHIFT: f64 = 58.4;
-        const SKEW: f64 = 0.183;
+        const X_SCALE: f64 = 6.85;
+        const X_SHIFT: f64 = 64.5;
+        const SKEW: f64 = 0.171;
 
         let exp: f64 = ((ply as f64 - X_SHIFT) / X_SCALE).exp();
         let base: f64 = 1.0 + exp;


### PR DESCRIPTION
`pleco` changes:
- Added `Board::see_ge` to determine if the static exchange of results in a winning material capture.
- Tests for `Board::see_ge`.
- Added `Board::player_piece_at_sq` for retrieving a player and piece at a `SQ`.
- Added `BitMove::is_okay()` and `BitMove::from_to`.
- Added `helper::piece_value_op` for testing the value for a `Option<PieceType>`.

`pleco_engine` changes:
- `see_ge` is added to the main search and MovePicker.
- Added a futility base checking for the `qsearch`.
- Benchmarks for a searching a mid-game.
- `MovePicker::next` now returns a `Option<BitMove>`.
- Modified the aspiration window delta (the search was performed with too small a window, consistently failing low). This has helped significantly with using less time in a game with a clock.
- Time Management parameters were changed for significantly better time usage.
- Increased Thread Stack Size.
