### PR TITLE
Update `pleco` to 0.3.11, Add Indexing for Table Bases.

### DIFF
--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -143,8 +143,8 @@ impl BoardState {
         let them = us.other_player();
         let ksq = board.king_sq(us);
 
-        self.checkers_bb = board.attackers_to(ksq, board.occ_all)
-            & board.occ[them as usize];
+        self.checkers_bb = board.attackers_to(ksq, board.occupied())
+            & board.bbs_player[them as usize];
 
         self.set_check_info(board);
         self.set_zob_hash(board);
@@ -192,7 +192,7 @@ impl BoardState {
     fn set_zob_hash(&mut self, board: &Board) {
         let mut b: BitBoard = board.occupied();
         while let Some(sq) = b.pop_some_lsb() {
-            let (player, piece) = board.piece_locations.player_piece_at(sq).unwrap();
+            let (player, piece) = board.piece_locations.piece_at(sq).player_piece_lossy();
             self.psq += psq(piece,player,sq);
             let key = z_square(sq, player, piece);
             self.zobrast ^= key;

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -192,11 +192,11 @@ impl BoardState {
     fn set_zob_hash(&mut self, board: &Board) {
         let mut b: BitBoard = board.occupied();
         while let Some(sq) = b.pop_some_lsb() {
-            let (player, piece) = board.piece_locations.piece_at(sq).player_piece_lossy();
-            self.psq += psq(piece,player,sq);
-            let key = z_square(sq, player, piece);
+            let piece =  board.piece_locations.piece_at(sq);
+            self.psq += psq(piece,sq);
+            let key = z_square(sq, piece);
             self.zobrast ^= key;
-            if piece == PieceType::P {
+            if piece.piece() == PieceType::P {
                 self.pawn_key ^= key;
             }
         }
@@ -220,7 +220,7 @@ impl BoardState {
             for piece in &ALL_PIECE_TYPES {
                 let count = board.piece_bb(*player, *piece).count_bits();
                 for n in 0..count {
-                    self.material_key ^= z_square(SQ(n), *player, *piece);
+                    self.material_key ^= z_square(SQ(n), Piece::make_lossy(*player, *piece));
                 }
                 if *piece != PieceType::P && *piece != PieceType::K {
                     self.nonpawn_material[*player as usize] +=

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -140,7 +140,7 @@ impl BoardState {
         self.nonpawn_material = [0; 2];
 
         let us = board.turn;
-        let them = us.other_player();
+        let them = !us;
         let ksq = board.king_sq(us);
 
         self.checkers_bb = board.attackers_to(ksq, board.occupied())

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -196,7 +196,7 @@ impl BoardState {
             self.psq += psq(piece,sq);
             let key = z_square(sq, piece);
             self.zobrast ^= key;
-            if piece.piece() == PieceType::P {
+            if piece.type_of() == PieceType::P {
                 self.pawn_key ^= key;
             }
         }

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -76,7 +76,7 @@ pub struct BoardState {
     /// Array of BitBoards where for Each Piece, gives a spot the piece can move to where
     /// the opposing player's king would be in check.
     pub check_sqs: [BitBoard; PIECE_TYPE_CNT],
-    /// returns the previous move, if any, that was played. Returns `BitMove::NULL` if there was no
+    /// The previous move, if any, that was played. Returns `BitMove::NULL` if there was no
     /// previous move played.
     pub prev_move: BitMove,
     /// Previous State of the board (from one move ago).
@@ -231,12 +231,14 @@ impl BoardState {
     }
 
     /// Return the previous BoardState from one move ago.
+    ///
+    /// If there was no previous state, returns `None`.
     #[inline]
     pub fn get_prev(&self) -> Option<Arc<BoardState>> {
         (&self).prev.as_ref().cloned()
     }
 
-    /// Iterates through all previous `BoardStates` and prints their information.
+    /// Iterates through all previous `BoardStates` and prints debug information for each.
     ///
     /// Used primarily for debugging.
     pub fn backtrace(&self) {

--- a/pleco/src/board/castle_rights.rs
+++ b/pleco/src/board/castle_rights.rs
@@ -128,14 +128,17 @@ impl Castling {
 
     /// Adds the Right to castle based on an `char`.
     ///
+    /// ```md
     /// `K` -> Add White King-side Castling bit.
     /// `Q` -> Add White Queen-side Castling bit.
     /// `k` -> Add Black King-side Castling bit.
     /// `q` -> Add Black Queen-side Castling bit.
+    /// `-` -> Do nothing.
+    /// ```
     ///
     /// # Panics
     ///
-    /// Panics of the char is not `K`, `Q`, `k`, or `q`.
+    /// Panics of the char is not `K`, `Q`, `k`, `q`, or `-`.
     pub fn add_castling_char(&mut self, c: char) {
         self.bits |= match c {
             'K' => Castling::WHITE_K.bits,
@@ -149,8 +152,8 @@ impl Castling {
 
     /// Returns a pretty String representing the castling state
     ///
-    /// Used for FEN Strings, with ('K' | 'Q') representing white castling abilities,
-    /// and ('k' | 'q') representing black castling abilities. If there are no bits set,
+    /// Used for FEN Strings, with (`K` | `Q`) representing white castling abilities,
+    /// and (`k` | `q`) representing black castling abilities. If there are no bits set,
     /// returns a String containing "-".
     pub fn pretty_string(&self) -> String {
         if self.no_castling() {

--- a/pleco/src/board/fen.rs
+++ b/pleco/src/board/fen.rs
@@ -1,10 +1,19 @@
-//! Contains fen functions and constants.
+//! Contains various FEN (Forsyth–Edwards Notation) functions and constants.
+//!
+//! A FEN string is a way of describing the particular state of a chess game.
+//!
+//! For example, the start position fen is
+//! `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1`.
+//!
+//! See [this Wikipedia article](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)
+//! for more information.
 
 
 use super::{Board,FenBuildError};
 use {BitBoard, PieceType, Player, Rank, SQ};
 use super::super::core::sq::NO_SQ;
 
+/// The fen string for the start position.
 pub const OPENING_POS_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
 #[doc(hidden)]

--- a/pleco/src/board/fen.rs
+++ b/pleco/src/board/fen.rs
@@ -111,8 +111,8 @@ pub fn is_valid_fen(board: Board) -> Result<Board,FenBuildError> {
         let sq_1bb = checks.lsb();
         let sq_2 = (checks & !sq_1bb).to_sq();
         let sq_1 = sq_1bb.to_sq();
-        let piece_1 = board.piece_at_sq(sq_1).unwrap();
-        let piece_2 = board.piece_at_sq(sq_2).unwrap();
+        let piece_1 = board.piece_at_sq(sq_1).piece();
+        let piece_2 = board.piece_at_sq(sq_2).piece();
 
         // Some combinations of pieces can never check the king at the same time.
         if piece_1 == PieceType::P {
@@ -153,8 +153,13 @@ pub fn is_valid_fen(board: Board) -> Result<Board,FenBuildError> {
                 }
 
                 let ep_p_sq = ep_sq - SQ(8);
-                let ep_player = board.player_at_sq(ep_p_sq).ok_or(FenBuildError::EPSquareInvalid{ep: ep_sq.to_string()})?;
-                let ep_piece = board.piece_at_sq(ep_p_sq).ok_or(FenBuildError::EPSquareInvalid{ep: ep_sq.to_string()})?;
+
+                let (ep_player, ep_piece) = board.piece_at_sq(ep_p_sq).player_piece_lossy();
+
+                if ep_piece == PieceType::None {
+                    return Err(FenBuildError::EPSquareInvalid {ep: ep_sq.to_string()});
+                }
+
 
                 if ep_player != Player::Black ||  ep_piece != PieceType::P {
                     return Err(FenBuildError::EPSquareInvalid {ep: ep_sq.to_string()});
@@ -166,8 +171,12 @@ pub fn is_valid_fen(board: Board) -> Result<Board,FenBuildError> {
                 }
 
                 let ep_p_sq = ep_sq + SQ(8);
-                let ep_player = board.player_at_sq(ep_p_sq).ok_or(FenBuildError::EPSquareInvalid{ep: ep_sq.to_string()})?;
-                let ep_piece = board.piece_at_sq(ep_p_sq).ok_or(FenBuildError::EPSquareInvalid{ep: ep_sq.to_string()})?;
+
+                let (ep_player, ep_piece) = board.piece_at_sq(ep_p_sq).player_piece_lossy();
+
+                if ep_piece == PieceType::None {
+                    return Err(FenBuildError::EPSquareInvalid {ep: ep_sq.to_string()});
+                }
 
                 if ep_player != Player::White ||  ep_piece != PieceType::P {
                     return Err(FenBuildError::EPSquareInvalid {ep: ep_sq.to_string()});

--- a/pleco/src/board/fen.rs
+++ b/pleco/src/board/fen.rs
@@ -111,8 +111,8 @@ pub fn is_valid_fen(board: Board) -> Result<Board,FenBuildError> {
         let sq_1bb = checks.lsb();
         let sq_2 = (checks & !sq_1bb).to_sq();
         let sq_1 = sq_1bb.to_sq();
-        let piece_1 = board.piece_at_sq(sq_1).piece();
-        let piece_2 = board.piece_at_sq(sq_2).piece();
+        let piece_1 = board.piece_at_sq(sq_1).type_of();
+        let piece_2 = board.piece_at_sq(sq_2).type_of();
 
         // Some combinations of pieces can never check the king at the same time.
         if piece_1 == PieceType::P {

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -60,7 +60,7 @@ use board::*;
 use core::piece_move::{MoveFlag, BitMove, PreMoveInfo, ScoringMove};
 use core::move_list::{MoveList,ScoringMoveList,MVPushable};
 
-use {SQ, BitBoard};
+use {SQ, BitBoard, Piece, PieceType};
 
 
 //                   Legal    PseudoLegal
@@ -284,7 +284,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
 
         // discovered check candidates
         while let Some(from) = disc_check.pop_some_lsb() {
-            let piece: PieceType = self.board.piece_at_sq(from).unwrap();
+            let piece: PieceType = self.board.piece_at_sq(from).piece();
             if piece != PieceType::P {
                 let mut b: BitBoard = self.moves_bb(piece, from) & !self.board.occupied();
                 if piece == PieceType::K {
@@ -346,7 +346,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
     fn castling_side<L: Legality, P: PlayerTrait>(&mut self, side: CastleType) {
         // Make sure we can castle AND the space between the king / rook is clear AND the piece at castling_side is a Rook
         if !self.board.castle_impeded(side) && self.board.can_castle(P::player(), side)
-            && self.board.piece_at_sq(self.board.castling_rook_square(side)) == Some(PieceType::R) {
+            && self.board.piece_at_sq(self.board.castling_rook_square(side)).piece() == PieceType::R {
             let king_side: bool = { side == CastleType::KingSide };
 
             let ksq: SQ = self.board.king_sq(P::player());

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -572,6 +572,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             PieceType::R => rook_moves(self.occ, square),
             PieceType::Q => queen_moves(self.occ, square),
             PieceType::K => king_moves(square),
+            _ => BitBoard(0)
         }
     }
 
@@ -589,6 +590,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             PieceType::R => rook_moves(self.occ, square),
             PieceType::Q => queen_moves(self.occ, square),
             PieceType::K => king_moves(square),
+            _ => BitBoard(0)
         }
     }
 

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -147,7 +147,8 @@ impl MoveGen {
         movelist
     }
 
-    /// Extends the current list of moves of a certain Legality, and Generation type.
+    /// Extends the current list of moves of a certain Legality, and Generation type. This method
+    /// will correctly set the new length of the list.
     ///
     /// # Safety
     ///

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -1,17 +1,26 @@
 //! perft, or Performance Test, Move Path Enumeration, tests the correctness of move-generation.
 //!
-//! Use these functions on a `Board` to test that the correct amount of leaf nodes are created.
+//! Use these functions on a [`Board`] to test that the correct amount of leaf nodes are created.
+//!
+//! [`Board`]: ../struct.Board.html
 
 use super::{Board,MoveList};
 
 /// Holds all information about the number of nodes counted.
 pub struct PerftNodes {
+    /// Total number of nodes counted.
     pub nodes: u64,
+    /// Number of capturing moves, including en-passant moves.
     pub captures: u64,
+    /// Number of En-Passant moves.
     pub en_passant: u64,
+    /// Number of Castles.
     pub castles: u64,
+    /// The number of promotions
     pub promotions: u64,
+    /// The number of checking moves.
     pub checks: u64,
+    /// The number of moves resulting in a checkmate.
     pub checkmates: u64,
 }
 

--- a/pleco/src/board/piece_locations.rs
+++ b/pleco/src/board/piece_locations.rs
@@ -46,7 +46,7 @@ impl PieceLocations {
     /// This function is unsafe as Zeros represent Pawns, and therefore care mus be taken
     /// to iterate through every square and ensure the correct piece or lack of piece
     /// is placed.
-    pub const fn default() -> PieceLocations {
+    pub(crate) const fn default() -> PieceLocations {
         PieceLocations { data: [0; 64] }
     }
 

--- a/pleco/src/board/piece_locations.rs
+++ b/pleco/src/board/piece_locations.rs
@@ -8,6 +8,7 @@
 use std::mem;
 
 use core::*;
+use core::masks::*;
 use core::sq::SQ;
 use super::FenBuildError;
 
@@ -30,7 +31,7 @@ pub struct PieceLocations {
     // 1xxx -> Black Piece
 
     // array of u8's, with standard ordering mapping index to square
-    data: [u8; 64],
+    data: [Piece; SQ_CNT],
 }
 
 
@@ -38,16 +39,7 @@ pub struct PieceLocations {
 impl PieceLocations {
     /// Constructs a new `PieceLocations` with a default of no pieces on the board.
     pub const fn blank() -> PieceLocations {
-        PieceLocations { data: [0b0111; 64] }
-    }
-
-    /// Constructs a new `PieceLocations` with the memory at a default of Zeros.
-    ///
-    /// This function is unsafe as Zeros represent Pawns, and therefore care mus be taken
-    /// to iterate through every square and ensure the correct piece or lack of piece
-    /// is placed.
-    pub(crate) const fn default() -> PieceLocations {
-        PieceLocations { data: [0; 64] }
+        PieceLocations { data: [Piece::None; 64] }
     }
 
     /// Places a given piece for a given player at a certain square.
@@ -57,8 +49,9 @@ impl PieceLocations {
     /// Panics if Square is of index higher than 63.
     #[inline]
     pub fn place(&mut self, square: SQ, player: Player, piece: PieceType) {
-        assert!(square.is_okay());
-        self.data[square.0 as usize] = self.create_sq(player, piece);
+        debug_assert!(square.is_okay());
+        debug_assert!(piece.is_real());
+        self.data[square.0 as usize] = Piece::make_lossy(player, piece);
     }
 
     /// Removes a Square.
@@ -68,8 +61,8 @@ impl PieceLocations {
     /// Panics if Square is of index higher than 63.
     #[inline]
     pub fn remove(&mut self, square: SQ) {
-        assert!(square.is_okay());
-        self.data[square.0 as usize] = 0b0111
+        debug_assert!(square.is_okay());
+        self.data[square.0 as usize] = Piece::None;
     }
 
     /// Returns the Piece at a `SQ`, Or None if the square is empty.
@@ -78,119 +71,23 @@ impl PieceLocations {
     ///
     /// Panics if square is of index higher than 63.
     #[inline]
-    pub fn piece_at(&self, square: SQ) -> Option<PieceType> {
+    pub fn piece_at(&self, square: SQ) -> Piece {
         debug_assert!(square.is_okay());
-        let byte: u8 = self.data[square.0 as usize] & 0b0111;
-        match byte {
-            0b0000 => Some(PieceType::P),
-            0b0001 => Some(PieceType::N),
-            0b0010 => Some(PieceType::B),
-            0b0011 => Some(PieceType::R),
-            0b0100 => Some(PieceType::Q),
-            0b0101 => Some(PieceType::K),
-            0b0110 => unreachable!(), // Undefined
-            0b0111 => None,
-            _ => unreachable!(),
-        }
+        self.data[square.0 as usize]
     }
 
-    /// Returns the Piece at a `SQ` for a given player.
-    ///
-    /// If there is no piece at that square, or there is a piece of another player at that square,
-    /// returns None.
-    ///
-    /// # Panics
-    ///
-    /// Panics if Square is of index higher than 63.
-    #[inline]
-    pub fn piece_at_for_player(&self, square: SQ, player: Player) -> Option<PieceType> {
-        let op = self.player_piece_at(square);
-        if op.is_some() {
-            let p = op.unwrap();
-            if p.0 == player {
-                Some(p.1)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    /// Returns the `Player` (if any) is occupying a `SQ`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if Square is of index higher than 63.
-    #[inline]
-    pub fn player_at(&self, square: SQ) -> Option<Player> {
-        let byte: u8 = self.data[square.0 as usize];
-        if byte == 0b0111 || byte == 0b1111 {
-            return None;
-        }
-        if byte < 8 {
-            Some(Player::White)
-        } else {
-            Some(Player::Black)
-        }
-    }
-
-    /// Returns the `Player` (if any) is occupying a `SQ`.
-    ///
-    /// # Safety
-    ///
-    /// Will return an incorrect result if there is no player at the square.
-    #[inline]
-    pub unsafe fn unchecked_player_at(&self, square: SQ) -> Player {
-        let byte: u8 = self.data[square.0 as usize];
-        if byte < 8 {
-            Player::White
-        } else {
-            Player::Black
-        }
-    }
-
-    /// Returns a Tuple of `(Player,Piece)` of the player and associated piece at a
-    /// given square. Returns None if the square is unoccupied.
-    ///
-    /// # Panics
-    ///
-    /// Panics if Square is of index higher than 63.
-    #[inline]
-    pub fn player_piece_at(&self, square: SQ) -> Option<(Player, PieceType)> {
-        let byte: u8 = self.data[square.0 as usize];
-        match byte {
-            0b0000 => Some((Player::White, PieceType::P)),
-            0b0001 => Some((Player::White, PieceType::N)),
-            0b0010 => Some((Player::White, PieceType::B)),
-            0b0011 => Some((Player::White, PieceType::R)),
-            0b0100 => Some((Player::White, PieceType::Q)),
-            0b0101 => Some((Player::White, PieceType::K)),
-            0b0110 => unreachable!(), // Undefined
-            0b0111 | 0b1111 => None,
-            0b1000 => Some((Player::Black, PieceType::P)),
-            0b1001 => Some((Player::Black, PieceType::N)),
-            0b1010 => Some((Player::Black, PieceType::B)),
-            0b1011 => Some((Player::Black, PieceType::R)),
-            0b1100 => Some((Player::Black, PieceType::Q)),
-            0b1101 => Some((Player::Black, PieceType::K)),
-            0b1110 => unreachable!(), // Undefined
-            _ => unreachable!(),
-        }
-    }
-
-    /// Returns if there is a `SQ` is occupied.
+    /// Returns if a square is occupied.
     #[inline]
     pub fn at_square(&self, square: SQ) -> bool {
         assert!(square.is_okay());
-        let byte: u8 = self.data[square.0 as usize];
-        byte != 0b0111 && byte != 0b1111
+        self.data[square.0 as usize] != Piece::None
+
     }
 
     /// Returns the first square (if any) that a piece / player is at.
     #[inline]
     pub fn first_square(&self, piece: PieceType, player: Player) -> Option<SQ> {
-        let target = self.create_sq(player, piece);
+        let target = Piece::make_lossy(player, piece);
         for x in 0..64 {
             if target == self.data[x as usize] {
                 return Some(SQ(x));
@@ -246,23 +143,6 @@ impl PieceLocations {
         }
         Ok(loc)
     }
-
-    /// Helper method to return the bit representation of a given piece and player.
-    #[inline]
-    fn create_sq(&self, player: Player, piece: PieceType) -> u8 {
-        let mut loc: u8 = match piece {
-            PieceType::P => 0b0000,
-            PieceType::N => 0b0001,
-            PieceType::B => 0b0010,
-            PieceType::R => 0b0011,
-            PieceType::Q => 0b0100,
-            PieceType::K => 0b0101,
-        };
-        if player == Player::Black {
-            loc |= 0b1000;
-        }
-        loc
-    }
 }
 
 impl Clone for PieceLocations {
@@ -296,7 +176,7 @@ impl Iterator for PieceLocationsIter {
     fn next(&mut self) -> Option<Self::Item> {
         if self.sq >= SQ::NONE {
             None
-        } else if let Some((plyr, piece)) = self.locations.player_piece_at(self.sq) {
+        } else if let Some((plyr, piece)) = self.locations.piece_at(self.sq).player_piece() {
             let sq = self.sq;
             self.sq += SQ(1);
             Some((sq, plyr, piece))
@@ -316,50 +196,5 @@ impl IntoIterator for PieceLocations {
             locations: self,
             sq: SQ(0),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::PieceLocations;
-    use {SQ, PieceType, Player};
-
-    #[test]
-    fn piece_loc_blank() {
-        let mut l = PieceLocations::blank();
-        for s in 0..64 {
-            assert!(l.piece_at(SQ(s)).is_none());
-        }
-        l.place(SQ(3), Player::White, PieceType::P);
-        assert_eq!(l.piece_at(SQ(3)).unwrap(), PieceType::P);
-        assert_eq!(l.player_at(SQ(3)).unwrap(), Player::White);
-        assert_eq!(l.player_piece_at(SQ(3)).unwrap(),(Player::White, PieceType::P));
-        assert!(l.at_square(SQ(3)));
-        for s in 0..64 {
-            if s != 3 {
-                assert!(l.piece_at(SQ(s)).is_none());
-            }
-        }
-        l.place(SQ(3), Player::Black, PieceType::K);
-        assert_eq!(l.piece_at(SQ(3)).unwrap(), PieceType::K);
-        assert_eq!(l.player_at(SQ(3)).unwrap(), Player::Black);
-        assert_eq!(l.player_piece_at(SQ(3)).unwrap(),(Player::Black, PieceType::K));
-        assert!(l.at_square(SQ(3)));
-        assert!(l.contains(PieceType::K, Player::Black));
-        for s in 0..64 {
-            if s != 3 {
-                assert!(l.piece_at(SQ(s)).is_none());
-            }
-        }
-        l.remove(SQ(3));
-        for s in 0..64 {
-            assert!(l.piece_at(SQ(s)).is_none());
-        }
-        l.remove(SQ(3));
-        for s in 0..64 {
-            assert!(l.piece_at(SQ(s)).is_none());
-        }
-        let c = l.clone();
-        assert!(c == l);
     }
 }

--- a/pleco/src/board/piece_locations.rs
+++ b/pleco/src/board/piece_locations.rs
@@ -170,24 +170,27 @@ pub struct PieceLocationsIter {
 }
 
 impl Iterator for PieceLocationsIter {
-    type Item = (SQ,Player,PieceType);
+    type Item = (SQ,Piece);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.sq >= SQ::NONE {
             None
-        } else if let Some((plyr, piece)) = self.locations.piece_at(self.sq).player_piece() {
-            let sq = self.sq;
-            self.sq += SQ(1);
-            Some((sq, plyr, piece))
         } else {
-            self.next()
+            let piece = self.locations.piece_at(self.sq);
+            if piece != Piece::None {
+                let sq = self.sq;
+                self.sq += SQ(1);
+                return Some((sq, piece));
+            } else {
+                return self.next();
+            }
         }
     }
 }
 
 impl IntoIterator for PieceLocations {
-    type Item = (SQ,Player,PieceType);
+    type Item = (SQ,Piece);
     type IntoIter = PieceLocationsIter;
 
     #[inline(always)]

--- a/pleco/src/bots/iterative_parallel_mvv_lva.rs
+++ b/pleco/src/bots/iterative_parallel_mvv_lva.rs
@@ -292,7 +292,7 @@ fn q_science_criteria(m: BitMove, _board: &Board) -> bool {
 
 fn mvv_lva_sort(moves: &mut [BitMove], board: &Board) {
     moves.sort_by_key(|a| {
-        let piece = board.piece_at_sq((*a).get_src()).piece();
+        let piece = board.piece_at_sq((*a).get_src()).type_of();
 
         if a.is_capture() {
             board.captured_piece(*a).unwrap().value() - piece.value()

--- a/pleco/src/bots/iterative_parallel_mvv_lva.rs
+++ b/pleco/src/bots/iterative_parallel_mvv_lva.rs
@@ -292,7 +292,7 @@ fn q_science_criteria(m: BitMove, _board: &Board) -> bool {
 
 fn mvv_lva_sort(moves: &mut [BitMove], board: &Board) {
     moves.sort_by_key(|a| {
-        let piece = board.piece_at_sq((*a).get_src()).unwrap();
+        let piece = board.piece_at_sq((*a).get_src()).piece();
 
         if a.is_capture() {
             board.captured_piece(*a).unwrap().value() - piece.value()

--- a/pleco/src/core/bitboard.rs
+++ b/pleco/src/core/bitboard.rs
@@ -222,25 +222,6 @@ impl BitBoard {
         }
     }
 
-    /// Array containing all the `BitBoards` for of the starting position, for each player and piece.
-    pub const fn start_bbs() -> [[BitBoard; PIECE_TYPE_CNT]; PLAYER_CNT] {
-        [[
-            BitBoard(START_W_PAWN),
-            BitBoard(START_W_KNIGHT),
-            BitBoard(START_W_BISHOP),
-            BitBoard(START_W_ROOK),
-            BitBoard(START_W_QUEEN),
-            BitBoard(START_W_KING),
-        ], [
-            BitBoard(START_B_PAWN),
-            BitBoard(START_B_KNIGHT),
-            BitBoard(START_B_BISHOP),
-            BitBoard(START_B_ROOK),
-            BitBoard(START_B_QUEEN),
-            BitBoard(START_B_KING),
-        ], ]
-    }
-
     /// Returns a clone of a `[[BitBoard; 6]; 2]`. Used to duplicate occupancy `BitBoard`s of each
     /// piece for each player.
     #[inline(always)]

--- a/pleco/src/core/masks.rs
+++ b/pleco/src/core/masks.rs
@@ -5,7 +5,9 @@ use super::sq::SQ;
 /// The total number of players on a chessboard.
 pub const PLAYER_CNT: usize = 2;
 /// The total number of types of pieces on a chessboard.
-pub const PIECE_TYPE_CNT: usize = 6;
+pub const PIECE_TYPE_CNT: usize = 8;
+/// The total number of types of pieces & player combinations on a chessboard.
+pub const PIECE_CNT: usize = 16;
 /// The total number of squares on a chessboard.
 pub const SQ_CNT: usize = 64;
 /// The total number of files on a chessboard.
@@ -115,10 +117,6 @@ pub const NORTH_WEST: i8 = 7;
 pub const SOUTH_EAST: i8 = -7;
 /// Direction of going southwest on a chessboard.
 pub const SOUTH_WEST: i8 = -9;
-
-/// Array for all pieces and players that is zeroed.
-pub const BLANK_BIT_BOARDS: [[u64; PIECE_TYPE_CNT]; PLAYER_CNT] =
-    [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]];
 
 /// Array for starting occupancy boards for both players.
 pub const START_OCC_BOARDS: [u64; PLAYER_CNT] = [START_WHITE_OCC, START_BLACK_OCC];
@@ -247,8 +245,8 @@ pub const SQ_DISPLAY_ORDER: [u8; SQ_CNT] = [56, 57, 58, 59, 60, 61, 62, 63,
 
 /// Characters for each combination of player and piece.
 pub const PIECE_DISPLAYS: [[char; PIECE_TYPE_CNT]; PLAYER_CNT] = [
-    ['P', 'N', 'B', 'R', 'Q', 'K'],
-    ['p', 'n', 'b', 'r', 'q', 'k'],
+    ['_', 'P', 'N', 'B', 'R', 'Q', 'K', '*'],
+    ['_', 'p', 'n', 'b', 'r', 'q', 'k', '*'],
 ];
 
 /// Characters for each file, index from file A to file H.

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -56,6 +56,7 @@ pub static ALL_RANKS: [Rank; RANK_CNT] = [
 
 /// Enum to represent the Players White & Black.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
 pub enum Player {
     White = 0,
     Black = 1,
@@ -74,10 +75,7 @@ impl Player {
     /// ```
     #[inline(always)]
     pub fn other_player(&self) -> Player {
-        match *self {
-            Player::White => Player::Black,
-            Player::Black => Player::White,
-        }
+        !(*self)
     }
 
     /// Returns the relative square from a given square.
@@ -138,6 +136,17 @@ impl Player {
 //        ALL_RANKS[((rank as u8) ^ (*self as u8 * 7)) as usize]
         unsafe {
             mem::transmute::<u8,Rank>(r)
+        }
+    }
+}
+
+impl Not for Player {
+    type Output = Player;
+
+    fn not(self) -> Self::Output {
+        let other: u8 = (self as u8) ^ 0b0000_0001;
+        unsafe {
+            mem::transmute(other)
         }
     }
 }
@@ -308,7 +317,7 @@ impl Piece {
 
     #[inline(always)]
     pub fn player_lossy(self) -> Player {
-        debug_assert_ne!(self, Piece::None);
+        assert_ne!(self, Piece::None);
         unsafe {
             mem::transmute((self as u8 >> 3) & 0b1)
         }

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -22,7 +22,7 @@ use std::mem;
 use std::ops::Not;
 
 /// Array of all possible pieces, indexed by their enum value.
-pub const ALL_PIECE_TYPES: [PieceType; PIECE_TYPE_CNT] =
+pub const ALL_PIECE_TYPES: [PieceType; PIECE_TYPE_CNT - 2] =
     [PieceType::P, PieceType::N, PieceType::B, PieceType::R, PieceType::Q, PieceType::K];
 
 
@@ -190,12 +190,14 @@ pub enum GenTypes {
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum PieceType {
-    K = 5,
-    Q = 4,
-    R = 3,
-    B = 2,
-    N = 1,
-    P = 0,
+    None = 0,
+    P = 1,
+    N = 2,
+    B = 3,
+    R = 4,
+    Q = 5,
+    K = 6,
+    All = 7
 }
 
 impl PieceType {
@@ -210,8 +212,22 @@ impl PieceType {
             PieceType::N | PieceType::B => 3,
             PieceType::R => 5,
             PieceType::Q => 8,
-            PieceType::K => 0,
+            _ => 0,
+
         }
+    }
+
+    pub fn as_option(self) -> Option<PieceType> {
+        if self == PieceType::None {
+            None
+        } else {
+            Some(self)
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_real(self) -> bool {
+        self != PieceType::None && self != PieceType::All
     }
 
     /// Return the lowercase character of a `Piece`.
@@ -224,6 +240,7 @@ impl PieceType {
             PieceType::R => 'r',
             PieceType::Q => 'q',
             PieceType::K => 'k',
+            _ => panic!(),
         }
     }
 
@@ -237,6 +254,7 @@ impl PieceType {
             PieceType::R => 'R',
             PieceType::Q => 'Q',
             PieceType::K => 'K',
+            _ => panic!(),
         }
     }
 }
@@ -249,11 +267,119 @@ impl fmt::Display for PieceType {
             PieceType::B => "Bishop",
             PieceType::R => "Rook",
             PieceType::Q => "Queen",
-            PieceType::K => "King"
+            PieceType::K => "King",
+            PieceType::All => "All",
+            PieceType::None => "",
         };
         f.pad(s)
     }
 }
+
+// TODO: documentation
+
+/// All possible Types of Pieces on a chessboard.
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Piece {
+    None        = 0b0000,
+    WhitePawn   = 0b0001,
+    WhiteKnight = 0b0010,
+    WhiteBishop = 0b0011,
+    WhiteRook   = 0b0100,
+    WhiteQueen  = 0b0101,
+    WhiteKing   = 0b0110,
+    BlackPawn   = 0b1001,
+    BlackKnight = 0b1010,
+    BlackBishop = 0b1011,
+    BlackRook   = 0b1100,
+    BlackQueen  = 0b1101,
+    BlackKing   = 0b1110
+}
+
+impl Piece {
+    #[inline(always)]
+    pub fn player(self) -> Option<Player> {
+        if self as u8 & 0b0111 == 0 {
+            None
+        } else {
+            Some(self.player_lossy())
+        }
+    }
+
+    #[inline(always)]
+    pub fn player_lossy(self) -> Player {
+        debug_assert_ne!(self, Piece::None);
+        unsafe {
+            mem::transmute((self as u8 >> 3) & 0b1)
+        }
+    }
+
+    #[inline(always)]
+    pub fn piece(self) -> PieceType {
+        unsafe {
+            mem::transmute(self as u8 & 0b111)
+        }
+    }
+
+    #[inline(always)]
+    pub fn player_piece(self) -> Option<(Player, PieceType)> {
+        if self == Piece::None {
+            None
+        } else {
+            Some(self.player_piece_lossy())
+        }
+    }
+
+    #[inline(always)]
+    pub fn player_piece_lossy(self) -> (Player, PieceType) {
+        (self.player_lossy(), self.piece())
+    }
+
+    #[inline(always)]
+    pub fn make(player: Player, piece_type: PieceType) -> Option<Piece> {
+        match piece_type {
+            PieceType::None => Some(Piece::None),
+            PieceType::All => None,
+            _ => Some(Piece::make_lossy(player, piece_type))
+        }
+    }
+
+    #[inline(always)]
+    pub fn make_lossy(player: Player, piece_type: PieceType) -> Piece {
+        debug_assert_ne!(piece_type, PieceType::All);
+        unsafe {
+            let bits: u8 = (player as u8) << 3 | piece_type as u8;
+            mem::transmute(bits)
+        }
+    }
+
+    pub fn character(self) -> Option<char> {
+        if self == Piece::None {
+            None
+        } else {
+            Some(self.character_lossy())
+        }
+    }
+
+    pub fn character_lossy(self) -> char {
+        match self {
+            Piece::None        => panic!(),
+            Piece::WhitePawn   => 'P',
+            Piece::WhiteKnight => 'N',
+            Piece::WhiteBishop => 'B',
+            Piece::WhiteRook   => 'R',
+            Piece::WhiteQueen  => 'Q',
+            Piece::WhiteKing   => 'K',
+            Piece::BlackPawn   => 'p',
+            Piece::BlackKnight => 'n',
+            Piece::BlackBishop => 'b',
+            Piece::BlackRook   => 'r',
+            Piece::BlackQueen  => 'q',
+            Piece::BlackKing   => 'k'
+        }
+    }
+}
+
 
 /// Enum for the Files of a Chessboard.
 #[repr(u8)]

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -315,7 +315,7 @@ impl Piece {
     }
 
     #[inline(always)]
-    pub fn piece(self) -> PieceType {
+    pub fn type_of(self) -> PieceType {
         unsafe {
             mem::transmute(self as u8 & 0b111)
         }
@@ -332,7 +332,7 @@ impl Piece {
 
     #[inline(always)]
     pub fn player_piece_lossy(self) -> (Player, PieceType) {
-        (self.player_lossy(), self.piece())
+        (self.player_lossy(), self.type_of())
     }
 
     #[inline(always)]

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -68,13 +68,13 @@ use super::*;
 use super::sq::SQ;
 
 // Castles have the src as the king bit and the dst as the rook
-const SRC_MASK: u16 = 0b0000_000000_111111;
-const DST_MASK: u16 = 0b0000_111111_000000;
+const SRC_MASK: u16     = 0b0000_000000_111111;
+const DST_MASK: u16     = 0b0000_111111_000000;
 const FROM_TO_MASK: u16 = 0b0000_111111_111111;
-const PR_MASK: u16 = 0b1000_000000_000000;
-const CP_MASK: u16 = 0b0100_000000_000000;
-const FLAG_MASK: u16 = 0b1111_000000_000000;
-const SP_MASK: u16 = 0b0011_000000_000000;
+const PR_MASK: u16      = 0b1000_000000_000000;
+const CP_MASK: u16      = 0b0100_000000_000000;
+const FLAG_MASK: u16    = 0b1111_000000_000000;
+const SP_MASK: u16      = 0b0011_000000_000000;
 
 /// Represents a singular move. 
 ///
@@ -116,16 +116,16 @@ pub enum MoveFlag {
 
 /// A Subset of `MoveFlag`, used to determine the overall classification of a move.
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[repr(u8)]
+#[repr(u16)]
 pub enum MoveType {
     /// The move is "Normal", So its not a castle, promotion, or en-passant.
-    Normal,
-    /// The move is a promotion.
-    Promotion,
+    Normal = 0,    //0b000x
     /// The move is castling move.
-    Castle,
+    Castle = 1,    //0b001x
     /// The move is an en-passant capture.
-    EnPassant,
+    EnPassant = 5, // 0b0101
+    /// The move is a promotion.
+    Promotion = 8,      //0b1xxx
 }
 
 /// Useful pre-encoding of a move's information before it is compressed into a `BitMove` struct.

--- a/pleco/src/helper/mod.rs
+++ b/pleco/src/helper/mod.rs
@@ -19,7 +19,7 @@ mod psqt;
 pub mod prelude;
 
 
-use {SQ,BitBoard,Player,PieceType,File,Rank};
+use {SQ,BitBoard,Player,PieceType,File,Rank,Piece};
 use core::score::{Score,Value};
 
 /// Helper structure for accessing statically-initialized tables and other constants.
@@ -182,8 +182,8 @@ impl Helper {
 
     /// Returns the zobrist hash of a specific player's piece being at a particular square.
     #[inline(always)]
-    pub fn z_square(&self, sq: SQ, player: Player, piece: PieceType) -> u64 {
-        prelude::z_square(sq, player, piece)
+    pub fn z_square(&self, sq: SQ, piece: Piece) -> u64 {
+        prelude::z_square(sq, piece)
     }
 
     /// Returns the zobrist hash of a given file having an en-passant square.
@@ -206,8 +206,8 @@ impl Helper {
 
     /// Returns the score for a player's piece being at a particular square.
     #[inline(always)]
-    pub fn psq(&self, piece: PieceType, player: Player, sq: SQ) -> Score {
-        prelude::psq(piece, player, sq)
+    pub fn psq(&self, piece: Piece,  sq: SQ) -> Score {
+        prelude::psq(piece, sq)
     }
 
     /// Returns the value of a piece for a player. If `eg` is true, it returns the end game value. Otherwise,

--- a/pleco/src/helper/prelude.rs
+++ b/pleco/src/helper/prelude.rs
@@ -16,7 +16,7 @@ use super::zobrist;
 use super::magic;
 use super::boards;
 
-use {SQ,BitBoard,Player,PieceType,File,Rank};
+use {SQ,BitBoard,Player,PieceType,File,Rank,Piece};
 use core::score::{Score,Value};
 
 use std::sync::atomic::{AtomicBool,Ordering,fence,compiler_fence};
@@ -184,8 +184,8 @@ pub fn passed_pawn_mask(player: Player, sq: SQ) -> BitBoard {
 
 /// Returns the Zobrist hash for a given square, and player / piece at that square.
 #[inline(always)]
-pub fn z_square(sq: SQ, player: Player, piece: PieceType) -> u64 {
-    zobrist::z_square(sq, player, piece)
+pub fn z_square(sq: SQ, piece: Piece) -> u64 {
+    zobrist::z_square(sq, piece)
 }
 
 /// Returns the zobrist hash for a given zobrist square.
@@ -218,8 +218,8 @@ pub fn z_no_pawns() -> u64 {
 
 /// Returns the score for a player's piece being at a particular square.
 #[inline(always)]
-pub fn psq(piece: PieceType, player: Player, sq: SQ) -> Score {
-    psqt::psq(piece, player, sq)
+pub fn psq(piece: Piece, sq: SQ) -> Score {
+    psqt::psq(piece, sq)
 }
 
 /// Returns the value of a piece for a player. If `eg` is true, it returns the end game value. Otherwise,

--- a/pleco/src/helper/psqt.rs
+++ b/pleco/src/helper/psqt.rs
@@ -3,6 +3,16 @@ use core::masks::*;
 use core::score::*;
 
 const BONUS: [[[Score; (FILE_CNT / 2)]; RANK_CNT]; PIECE_TYPE_CNT] = [
+    [    // NO PIECE
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+    ],
     [ // Pawn
         [ Score(  0, 0), Score(  0, 0), Score(  0, 0), Score( 0, 0) ],
         [ Score(-11, 7), Score(  6,-4), Score(  7, 8), Score( 3,-2) ],
@@ -62,6 +72,16 @@ const BONUS: [[[Score; (FILE_CNT / 2)]; RANK_CNT]; PIECE_TYPE_CNT] = [
         [ Score(118, 95), Score(159,155), Score( 84,176), Score( 41,174) ],
         [ Score( 87, 50), Score(128, 99), Score( 63,122), Score( 20,139) ],
         [ Score( 63,  9), Score( 88, 55), Score( 47, 80), Score(  0, 90) ]
+    ],
+    [    // ALL PIECE
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
+        [ Score(0, 0), Score(0, 0), Score(0, 0), Score(0, 0)],
     ]
 ];
 
@@ -69,12 +89,14 @@ static mut PSQ: [[[Score; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT] =
     [[[Score(0,0); SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT];
 
 static PIECE_VALUE: [[Value; PHASE_CNT]; PIECE_TYPE_CNT] =
-    [[ PAWN_MG,    PAWN_EG],  // White Pawn
+    [[0, 0],                 // Empty
+    [ PAWN_MG,    PAWN_EG],  // White Pawn
     [ KNIGHT_MG,  KNIGHT_EG],// White Knight
     [ BISHOP_MG,  BISHOP_EG],// White Bishop
     [ ROOK_MG,    ROOK_EG],  // White Rook
     [ QUEEN_MG,   QUEEN_MG], // White Queen
-    [ ZERO,       ZERO]];    // White King
+    [ ZERO,       ZERO],     // White King
+    [0, 0]];                 // All
 
 #[cold]
 pub fn init_psqt() {

--- a/pleco/src/helper/psqt.rs
+++ b/pleco/src/helper/psqt.rs
@@ -1,4 +1,4 @@
-use {Player,SQ,File,PieceType};
+use {Player,SQ,File,PieceType,Piece};
 use core::masks::*;
 use core::score::*;
 
@@ -85,8 +85,8 @@ const BONUS: [[[Score; (FILE_CNT / 2)]; RANK_CNT]; PIECE_TYPE_CNT] = [
     ]
 ];
 
-static mut PSQ: [[[Score; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT] =
-    [[[Score(0,0); SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT];
+static mut PSQ: [[Score; SQ_CNT]; PIECE_CNT] =
+    [[Score(0,0); SQ_CNT]; PIECE_CNT];
 
 static PIECE_VALUE: [[Value; PHASE_CNT]; PIECE_TYPE_CNT] =
     [[0, 0],                 // Empty
@@ -107,8 +107,8 @@ pub fn init_psqt() {
             let f: File = sq.file().min(!sq.file());
             let score = v + BONUS[piece][sq.rank() as usize][f as usize];
             unsafe {
-                PSQ[Player::White as usize][piece][s] = score;
-                PSQ[Player::Black as usize][piece][sq.flip().0 as usize] = -score;
+                PSQ[(Player::White as usize) << 3 | piece][s] = score;
+                PSQ[(Player::Black as usize) << 3 | piece][sq.flip().0 as usize] = -score;
             }
         }
     }
@@ -116,10 +116,10 @@ pub fn init_psqt() {
 
 /// Returns the score for a player's piece being at a particular square.
 #[inline(always)]
-pub fn psq(piece: PieceType, player: Player, sq: SQ) -> Score{
+pub fn psq(piece: Piece, sq: SQ) -> Score{
     debug_assert!(sq.is_okay());
     unsafe {
-        (*(*(PSQ.get_unchecked(player as usize)).get_unchecked(piece as usize)).get_unchecked(sq.0 as usize))
+        *(PSQ.get_unchecked(piece as usize)).get_unchecked(sq.0 as usize)
     }
 }
 
@@ -139,10 +139,10 @@ mod tests {
     #[test]
     fn psq_tes() {
         init_psqt();
-        assert_eq!(psq(PieceType::Q, Player::White, SQ::A1), -psq(PieceType::Q, Player::Black, SQ::A8));
-        assert_eq!(psq(PieceType::R, Player::White, SQ::A1), -psq(PieceType::R, Player::Black, SQ::A8));
-        assert_eq!(psq(PieceType::P, Player::White, SQ::B1), -psq(PieceType::P, Player::Black, SQ::B8));
-        assert_eq!(psq(PieceType::N, Player::Black, SQ::B4), -psq(PieceType::N, Player::White, SQ::B5));
+        assert_eq!(psq(Piece::WhiteQueen, SQ::A1), -psq(Piece::BlackQueen, SQ::A8));
+        assert_eq!(psq(Piece::WhiteRook, SQ::A1), -psq( Piece::BlackRook, SQ::A8));
+        assert_eq!(psq(Piece::WhitePawn, SQ::B1), -psq( Piece::BlackPawn, SQ::B8));
+        assert_eq!(psq(Piece::BlackKnight,  SQ::B4), -psq(Piece::WhiteKnight,SQ::B5));
     }
 
 }

--- a/pleco/src/helper/zobrist.rs
+++ b/pleco/src/helper/zobrist.rs
@@ -1,4 +1,4 @@
-use {Player,SQ,PieceType,BitBoard};
+use {Player,SQ,PieceType,BitBoard,Piece};
 use tools::prng::PRNG;
 use core::masks::*;
 
@@ -6,8 +6,8 @@ use core::masks::*;
 const ZOBRIST_SEED: u64 = 23_081;
 
 /// Zobrist key for each piece on each square.
-static mut ZOBRIST_PIECE_SQUARE: [[[u64; PIECE_TYPE_CNT]; PLAYER_CNT]; SQ_CNT] =
-    [[[0; PIECE_TYPE_CNT]; PLAYER_CNT]; SQ_CNT];
+static mut ZOBRIST_PIECE_SQUARE: [[u64; PIECE_CNT]; SQ_CNT] =
+    [[0; PIECE_CNT]; SQ_CNT];
 
 /// Zobrist key for each possible en-passant capturable file.
 static mut ZOBRIST_ENPASSANT: [u64; FILE_CNT] = [0; FILE_CNT]; // 8 * 8
@@ -28,9 +28,9 @@ pub fn init_zobrist() {
 
     unsafe {
         for i in 0..SQ_CNT {
-            for j in 0..PIECE_TYPE_CNT {
-                ZOBRIST_PIECE_SQUARE[i][0][j] = rng.rand();
-                ZOBRIST_PIECE_SQUARE[i][1][j] = rng.rand();
+            for j in (Piece::WhitePawn as usize)..(Piece::BlackKing as usize) {
+                ZOBRIST_PIECE_SQUARE[i][j] = rng.rand();
+                ZOBRIST_PIECE_SQUARE[i][j] = rng.rand();
             }
         }
 
@@ -56,10 +56,10 @@ pub fn init_zobrist() {
 }
 
 #[inline(always)]
-pub fn z_square(sq: SQ, player: Player, piece: PieceType) -> u64 {
+pub fn z_square(sq: SQ, piece: Piece) -> u64 {
     debug_assert!(sq.is_okay());
     unsafe {
-        ZOBRIST_PIECE_SQUARE[sq.0 as usize][player as usize][piece as usize]
+        *(*ZOBRIST_PIECE_SQUARE.get_unchecked(sq.0 as usize)).get_unchecked(piece as usize)
     }
 }
 

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -105,7 +105,7 @@ pub use core::move_list::{MoveList,ScoringMoveList};
 pub use core::sq::SQ;
 pub use core::bitboard::BitBoard;
 pub use helper::Helper;
-pub use core::{Player, PieceType, Rank, File};
+pub use core::{Player, PieceType, Rank, File, Piece};
 
 
 pub mod bot_prelude {

--- a/pleco/src/tools/eval.rs
+++ b/pleco/src/tools/eval.rs
@@ -71,12 +71,14 @@ const CHECK: i32 = 14;
 
 // Pawn, Knight, Bishop, Rook, Queen, King
 pub const PIECE_VALS: [i32; PIECE_TYPE_CNT] = [
+    0,
     PAWN_VALUE,
     KNIGHT_VALUE,
     BISHOP_VALUE,
     ROOK_VALUE,
     QUEEN_VALUE,
     KING_VALUE,
+    0,
 ];
 
 

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -67,7 +67,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.3.10" }
+pleco = { path = "../pleco", version = "0.3.11" }
 clippy = {version = "0.0.187", optional = true}
 chrono = "0.4.0"
 rand = "0.4.2"

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -92,7 +92,7 @@ impl RootMoveList {
     pub fn mvv_lva_sort(&mut self, board: &Board) {
         self.sort_by_key(|root_move| {
             let a = root_move.bit_move;
-            let piece = board.piece_at_sq((a).get_src()).piece();
+            let piece = board.piece_at_sq((a).get_src()).type_of();
 
             if a.is_capture() {
                 piece.value() - board.captured_piece(a).unwrap().value()

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -92,7 +92,7 @@ impl RootMoveList {
     pub fn mvv_lva_sort(&mut self, board: &Board) {
         self.sort_by_key(|root_move| {
             let a = root_move.bit_move;
-            let piece = board.piece_at_sq((a).get_src()).unwrap();
+            let piece = board.piece_at_sq((a).get_src()).piece();
 
             if a.is_capture() {
                 piece.value() - board.captured_piece(a).unwrap().value()

--- a/pleco_engine/src/search/eval.rs
+++ b/pleco_engine/src/search/eval.rs
@@ -655,7 +655,7 @@ impl <'a> Evaluation <'a> {
                                     | self.attacked_by[us as usize][PieceType::B as usize]);
 
             while let Some(s) = b.pop_some_lsb() {
-                let piece = self.board.piece_at_sq(s).piece();
+                let piece = self.board.piece_at_sq(s).type_of();
                 score += THREAT_BY_MINOR[piece as usize];
                 if piece != PieceType::P {
                     score += THREAT_BY_RANK * them.relative_rank_of_sq(s) as u8;
@@ -664,7 +664,7 @@ impl <'a> Evaluation <'a> {
 
             b = (self.board.piece_bb(them, PieceType::Q) | weak) & self.attacked_by[us as usize][PieceType::R as usize];
             while let Some(s) = b.pop_some_lsb() {
-                let piece = self.board.piece_at_sq(s).piece();
+                let piece = self.board.piece_at_sq(s).type_of();
                 score += THREAT_BY_ROOK[piece as usize];
                 if piece != PieceType::P {
                     score += THREAT_BY_RANK * them.relative_rank_of_sq(s) as u8;

--- a/pleco_engine/src/search/eval.rs
+++ b/pleco_engine/src/search/eval.rs
@@ -22,10 +22,11 @@ const KING_SIDE: BitBoard = BitBoard(FILE_E | FILE_F | FILE_G | FILE_H);
 
 const KING_FLANK: [BitBoard; FILE_CNT] = [QUEEN_SIDE, QUEEN_SIDE, QUEEN_SIDE, CENTER_FILES, CENTER_FILES, KING_SIDE, KING_SIDE, KING_SIDE];
 
-const KING_ATTACKS_WEIGHT: [i32; PIECE_TYPE_CNT] = [0, 78, 56, 45, 11, 0];
+const KING_ATTACKS_WEIGHT: [i32; PIECE_TYPE_CNT] = [0, 0, 78, 56, 45, 11, 0, 0];
 
 
 const MOBILITY_BONUS: [[Score; 32]; PIECE_TYPE_CNT] = [
+[   Score::ZERO; 32], // No Piece
 [   Score::ZERO; 32], // Pawns
 [   Score(-75,-76), Score(-57,-54), Score( -9,-28), Score( -2,-10), Score(  6,  5), Score( 14, 12), // Knights
     Score( 22, 26), Score( 29, 29), Score( 36, 29), Score::ZERO,          Score::ZERO,           Score::ZERO,
@@ -55,10 +56,11 @@ const MOBILITY_BONUS: [[Score; 32]; PIECE_TYPE_CNT] = [
     Score(106,184), Score(109,191), Score(113,206), Score(116,212), Score::ZERO,          Score::ZERO,
     Score::ZERO,          Score::ZERO
 ],
-[Score::ZERO; 32]
+[   Score::ZERO; 32],
+[   Score::ZERO; 32] // All piece
 ];
 
-const KING_PROTECTOR: [Score; PIECE_TYPE_CNT] = [Score(0,0), Score(-3, -5), Score(-4, -3), Score(-3, 0), Score(-1, 1), Score(0,0) ];
+const KING_PROTECTOR: [Score; PIECE_TYPE_CNT] = [Score(0,0), Score(0,0), Score(-3, -5), Score(-4, -3), Score(-3, 0), Score(-1, 1), Score(0,0), Score(0,0)];
 
 // Outpost[knight/bishop][supported by pawn] contains bonuses for minor
 // pieces if they can reach an outpost square, bigger if that square is
@@ -76,11 +78,11 @@ const ROOK_ON_FILE: [Score; 2] = [Score(20, 7), Score(45, 20)];
 // which piece type attacks which one. Attacks on lesser pieces which are
 // pawn-defended are not considered.
 const THREAT_BY_MINOR: [Score; PIECE_TYPE_CNT] = [
-    Score(0, 0), Score(0, 33), Score(45, 43), Score(46, 47), Score(72, 107), Score(48, 118)
+    Score(0, 0), Score(0, 0), Score(0, 33), Score(45, 43), Score(46, 47), Score(72, 107), Score(48, 118), Score(0, 0)
 ];
 
 const THREAT_BY_ROOK: [Score; PIECE_TYPE_CNT] = [
-    Score(0, 0), Score(0, 25), Score(40, 62), Score(40, 59), Score(0, 34), Score(35, 48)
+    Score(0, 0), Score(0, 0), Score(0, 25), Score(40, 62), Score(40, 59), Score(0, 34), Score(35, 48), Score(0, 0),
 ];
 
 // ThreatByKing[on one/on many] contains bonuses for king attacks on

--- a/pleco_engine/src/search/eval.rs
+++ b/pleco_engine/src/search/eval.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Add;
 use std::mem;
-use pleco::{Board,BitBoard,SQ,Rank,File,Player,PieceType};
+use pleco::{Board,BitBoard,SQ,Rank,File,Player,PieceType,Piece};
 use pleco::core::mono_traits::*;
 use pleco::core::score::*;
 use pleco::core::masks::*;
@@ -655,7 +655,7 @@ impl <'a> Evaluation <'a> {
                                     | self.attacked_by[us as usize][PieceType::B as usize]);
 
             while let Some(s) = b.pop_some_lsb() {
-                let piece = self.board.piece_at_sq(s).unwrap();
+                let piece = self.board.piece_at_sq(s).piece();
                 score += THREAT_BY_MINOR[piece as usize];
                 if piece != PieceType::P {
                     score += THREAT_BY_RANK * them.relative_rank_of_sq(s) as u8;
@@ -664,7 +664,7 @@ impl <'a> Evaluation <'a> {
 
             b = (self.board.piece_bb(them, PieceType::Q) | weak) & self.attacked_by[us as usize][PieceType::R as usize];
             while let Some(s) = b.pop_some_lsb() {
-                let piece = self.board.piece_at_sq(s).unwrap();
+                let piece = self.board.piece_at_sq(s).piece();
                 score += THREAT_BY_ROOK[piece as usize];
                 if piece != PieceType::P {
                     score += THREAT_BY_RANK * them.relative_rank_of_sq(s) as u8;
@@ -743,7 +743,7 @@ impl <'a> Evaluation <'a> {
                     ebonus -= self.king_distance(us, P::up(block_sq)) as i32 * rr;
                 }
 
-                if self.board.piece_at_sq(block_sq).is_none() {
+                if self.board.piece_at_sq(block_sq) == Piece::None {
                     // If there is a rook or queen attacking/defending the pawn from behind,
                     // consider all the squaresToQueen. Otherwise consider only the squares
                     // in the pawn's path attacked or occupied by the enemy.

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -774,7 +774,7 @@ impl Searcher {
                 && !gives_check
                 && futility_base > -10000
                 && !self.board.advanced_pawn_push(mov) {
-                let piece_at = self.board.piece_at_sq(mov.get_src()).piece();
+                let piece_at = self.board.piece_at_sq(mov.get_src()).type_of();
                 futility_value = futility_base + piece_value(piece_at, true);
 
                 if futility_value <= alpha {
@@ -977,7 +977,7 @@ impl Searcher {
         let board = &self.board;
         self.root_moves().sort_by_key(|root_move| {
             let a = root_move.bit_move;
-            let piece = board.piece_at_sq((a).get_src()).piece();
+            let piece = board.piece_at_sq((a).get_src()).type_of();
 
             if a.is_capture() {
                 piece.value() - board.captured_piece(a).unwrap().value()

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -774,7 +774,7 @@ impl Searcher {
                 && !gives_check
                 && futility_base > -10000
                 && !self.board.advanced_pawn_push(mov) {
-                let piece_at = self.board.piece_at_sq(mov.get_src()).unwrap();
+                let piece_at = self.board.piece_at_sq(mov.get_src()).piece();
                 futility_value = futility_base + piece_value(piece_at, true);
 
                 if futility_value <= alpha {
@@ -885,7 +885,7 @@ impl Searcher {
             let ss_bef: &mut Stack = ss.offset(-1);
             if ss_bef.current_move.is_okay() {
                 let prev_sq = ss_bef.current_move.get_dest();
-                let (player, piece) = self.board.player_piece_at_sq(prev_sq).unwrap();
+                let (player, piece) = self.board.piece_at_sq(prev_sq).player_piece_lossy();
                 self.counter_moves[(player, piece, prev_sq)] = mov;
             }
         }
@@ -977,7 +977,7 @@ impl Searcher {
         let board = &self.board;
         self.root_moves().sort_by_key(|root_move| {
             let a = root_move.bit_move;
-            let piece = board.piece_at_sq((a).get_src()).unwrap();
+            let piece = board.piece_at_sq((a).get_src()).piece();
 
             if a.is_capture() {
                 piece.value() - board.captured_piece(a).unwrap().value()

--- a/pleco_engine/src/tables/butterfly.rs
+++ b/pleco_engine/src/tables/butterfly.rs
@@ -1,5 +1,6 @@
-
+use std::ops::{Index,IndexMut};
 use pleco::core::masks::*;
+use pleco::{Player, BitMove};
 
 use super::{StatBoard, NumStatBoard};
 
@@ -9,10 +10,37 @@ pub struct ButterflyHistory {
     a: [[i16; (SQ_CNT * SQ_CNT)]; PLAYER_CNT]
 }
 
-impl StatBoard<i16> for ButterflyHistory {
+// [Us][Move], Or rather [Us][To SQ][From SQ]
+#[allow(non_camel_case_types)]
+type BF_idx = (Player, BitMove);
+
+impl Index<BF_idx> for ButterflyHistory {
+    type Output = i16;
+
+    fn index(&self, idx: BF_idx) -> &Self::Output {
+        unsafe {
+            let from_to = idx.1.from_to() as usize;
+            self.a.get_unchecked(idx.0 as usize)   // [player]
+                .get_unchecked(from_to)            // [From SQ][to SQ]
+        }
+    }
+}
+
+impl IndexMut<BF_idx> for ButterflyHistory {
+    fn index_mut(&mut self, idx: BF_idx) -> &mut Self::Output {
+        unsafe {
+            let from_to = idx.1.from_to() as usize;
+            self.a.get_unchecked_mut(idx.0 as usize)   // [player]
+                .get_unchecked_mut(from_to)            // [From SQ][to SQ]
+        }
+    }
+}
+
+
+impl StatBoard<i16, BF_idx> for ButterflyHistory {
     const FILL: i16 = 0;
 }
 
-impl NumStatBoard for ButterflyHistory {
+impl NumStatBoard<BF_idx> for ButterflyHistory {
     const D: i16 = 324;
 }

--- a/pleco_engine/src/tables/capture_piece_history.rs
+++ b/pleco_engine/src/tables/capture_piece_history.rs
@@ -1,18 +1,48 @@
+use std::ops::{Index,IndexMut};
 use pleco::core::masks::*;
+use pleco::{PieceType, SQ,Player};
 
 use super::{StatBoard,NumStatCube};
 
-/// CapturePieceToBoards are addressed by a move's[player][piece][to][captured piece] information
+/// CapturePieceToBoards are addressed by a move's
+/// [player][moved piecetype][to][captured piecetype] information.
 pub struct CapturePieceToHistory {
     a: [[[[i16; PIECE_TYPE_CNT]; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
 }
 
+// [player][moved piecetype][to][captured piecetype]
+#[allow(non_camel_case_types)]
+type CP_idx = (Player, PieceType, SQ, PieceType);
 
-impl StatBoard<i16> for CapturePieceToHistory {
+impl Index<CP_idx> for CapturePieceToHistory {
+    type Output = i16;
+
+    fn index(&self, idx: CP_idx) -> &Self::Output {
+        unsafe {
+            self.a.get_unchecked(idx.0 as usize)    // [player]
+                .get_unchecked(idx.1 as usize)      // [Moved piece]
+                .get_unchecked((idx.2).0 as usize)  // [to square]
+                .get_unchecked(idx.3 as usize)      // [Captured piece]
+        }
+    }
+}
+
+impl IndexMut<CP_idx> for CapturePieceToHistory {
+    fn index_mut(&mut self, idx: CP_idx) -> &mut Self::Output {
+        unsafe {
+            self.a.get_unchecked_mut(idx.0 as usize)    // [player]
+                .get_unchecked_mut(idx.1 as usize)      // [Moved piece]
+                .get_unchecked_mut((idx.2).0 as usize)  // [to square]
+                .get_unchecked_mut(idx.3 as usize)      // [Captured piece]
+        }
+    }
+}
+
+impl StatBoard<i16, CP_idx> for CapturePieceToHistory {
     const FILL: i16 = 0;
 }
 
-impl NumStatCube for CapturePieceToHistory {
+impl NumStatCube<CP_idx> for CapturePieceToHistory {
     const D: i16 = 324;
     const W: i16 = 2;
 }

--- a/pleco_engine/src/tables/continuation.rs
+++ b/pleco_engine/src/tables/continuation.rs
@@ -1,21 +1,49 @@
 use std::mem;
+use std::ops::{Index,IndexMut};
 
 use pleco::core::masks::*;
+use pleco::{PieceType, SQ,Player};
 use super::{StatBoard,NumStatBoard};
+
 
 /// PieceToBoards are addressed by a move's [player][piece][to] information
 pub struct PieceToHistory {
     a: [[[i16; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
 }
 
-impl StatBoard<i16> for PieceToHistory {
+// [Us][Our Piece][To SQ]
+#[allow(non_camel_case_types)]
+type PTH_idx = (Player, PieceType, SQ);
+
+impl Index<PTH_idx> for PieceToHistory {
+    type Output = i16;
+
+    fn index(&self, idx: PTH_idx) -> &Self::Output {
+        unsafe {
+            self.a.get_unchecked(idx.0 as usize)    // [player]
+                .get_unchecked(idx.1 as usize)      // [Piece moved]
+                .get_unchecked((idx.2).0 as usize)  // [To SQ]
+        }
+    }
+}
+
+impl IndexMut<PTH_idx> for PieceToHistory {
+    fn index_mut(&mut self, idx: PTH_idx) -> &mut Self::Output {
+        unsafe {
+            self.a.get_unchecked_mut(idx.0 as usize)    // [player]
+                .get_unchecked_mut(idx.1 as usize)      // [Piece moved]
+                .get_unchecked_mut((idx.2).0 as usize)  // [To SQ]
+        }
+    }
+}
+
+impl StatBoard<i16, PTH_idx> for PieceToHistory {
     const FILL: i16 = 0;
 }
 
-impl NumStatBoard for PieceToHistory {
+impl NumStatBoard<PTH_idx> for PieceToHistory {
     const D: i16 = 936;
 }
-
 
 /// ContinuationHistory is the history of a given pair of moves, usually the
 /// current one given a previous one. History table is based on PieceToBoards
@@ -31,6 +59,32 @@ impl ContinuationHistory {
 
     pub fn clear(&mut self) {
         *self = unsafe {mem::zeroed()};
+    }
+}
+
+// [player][Our Moved Piece][To SQ]
+#[allow(non_camel_case_types)]
+type CH_idx = (Player, PieceType, SQ);
+
+impl Index<CH_idx> for ContinuationHistory {
+    type Output = PieceToHistory;
+
+    fn index(&self, idx: CH_idx) -> &Self::Output {
+        unsafe {
+            self.a.get_unchecked(idx.0 as usize)    // [player]
+                .get_unchecked(idx.1 as usize)      // [moved piece]
+                .get_unchecked((idx.2).0 as usize)  // [To SQ]
+        }
+    }
+}
+
+impl IndexMut<CH_idx> for ContinuationHistory {
+    fn index_mut(&mut self, idx: CH_idx) -> &mut Self::Output {
+        unsafe {
+            self.a.get_unchecked_mut(idx.0 as usize)    // [player]
+                .get_unchecked_mut(idx.1 as usize)      // [moved Piece]
+                .get_unchecked_mut((idx.2).0 as usize)  // [To SQ]
+        }
     }
 }
 

--- a/pleco_engine/src/tables/counter_move.rs
+++ b/pleco_engine/src/tables/counter_move.rs
@@ -1,11 +1,43 @@
+use std::ops::{Index,IndexMut};
 use pleco::core::masks::*;
-use pleco::{BitMove};
+use pleco::{PieceType, SQ,Player,BitMove};
+
 use super::StatBoard;
 
-/// PieceToBoards are addressed by a move's [player][piece][square] information
+
+/// CounterMoveHistory stores counter moves indexed by [player][piece][to] of the previous
+/// move
 pub struct CounterMoveHistory {
     a: [[[BitMove; SQ_CNT]; PIECE_TYPE_CNT]; PLAYER_CNT]
 }
-impl StatBoard<BitMove> for CounterMoveHistory {
+
+// [Us][Piece][To SQ]
+#[allow(non_camel_case_types)]
+type CM_idx = (Player, PieceType, SQ);
+
+impl Index<CM_idx> for CounterMoveHistory {
+    type Output = BitMove;
+
+    fn index(&self, idx: CM_idx) -> &Self::Output {
+        unsafe {
+            self.a.get_unchecked(idx.0 as usize)    // [Player Moved]
+                .get_unchecked(idx.1 as usize)      // [Piece Moved]
+                .get_unchecked((idx.2).0 as usize)  // [To SQ]
+        }
+    }
+}
+
+impl IndexMut<CM_idx> for CounterMoveHistory {
+    fn index_mut(&mut self, idx: CM_idx) -> &mut Self::Output {
+        unsafe {
+            self.a.get_unchecked_mut(idx.0 as usize)    // [Player Moved]
+                .get_unchecked_mut(idx.1 as usize)      // [Piece Moved]
+                .get_unchecked_mut((idx.2).0 as usize)  // [To SQ]
+        }
+    }
+}
+
+
+impl StatBoard<BitMove, CM_idx> for CounterMoveHistory {
     const FILL: BitMove = BitMove::null();
 }

--- a/pleco_engine/src/tables/material.rs
+++ b/pleco_engine/src/tables/material.rs
@@ -17,18 +17,18 @@ pub const SCALE_FACTOR_MAX: u8    = 128;
 pub const SCALE_FACTOR_NONE: u8   = 255;
 
 // Polynomial material imbalance parameters
-const QUADRATIC_OURS: [[i32; PIECE_TYPE_CNT]; PIECE_TYPE_CNT] = [
-    [1667,    0,   0,     0,     0,   0 ], // Bishop pair
-    [  40,    0,   0,     0,     0,   0 ], // Pawn
-    [  32,  255,  -3,     0,     0,   0 ], // Knight      OUR PIECES
-    [   0,  104,   4,     0,     0,   0 ], // Bishop
-    [ -26,   -2,  47,   105,  -149,   0 ], // Rook
-    [-189,   24, 117,   133,  -134, -10 ]  // Queen
+const QUADRATIC_OURS: [[i32; PIECE_TYPE_CNT - 2]; PIECE_TYPE_CNT - 2] = [
+    [1667,    0,   0,     0,     0,   0], // Bishop pair
+    [  40,    0,   0,     0,     0,   0], // Pawn
+    [  32,  255,  -3,     0,     0,   0], // Knight      OUR PIECES
+    [   0,  104,   4,     0,     0,   0], // Bishop
+    [ -26,   -2,  47,   105,  -149,   0], // Rook
+    [-189,   24, 117,   133,  -134, -10]  // Queen
 ]; // pair pawn knight bishop rook queen
    //            OUR PIECES
 
 
-const QUADRATIC_THEIRS: [[i32; PIECE_TYPE_CNT]; PIECE_TYPE_CNT] = [
+const QUADRATIC_THEIRS: [[i32; PIECE_TYPE_CNT - 2]; PIECE_TYPE_CNT - 2] = [
     [   0,    0,   0,     0,    0,    0 ], // Bishop pair
     [  36,    0,   0,     0,    0,    0 ], // Pawn
     [   9,   63,   0,     0,    0,    0 ], // Knight      OUR PIECES
@@ -127,7 +127,7 @@ impl Material {
         let w_pair_bish: u8 = (w_bishop_count > 1) as u8;
         let b_pair_bish: u8 = (b_bishop_count > 1) as u8;
 
-        let piece_counts: [[u8; PIECE_TYPE_CNT]; PLAYER_CNT] = [
+        let piece_counts: [[u8; PIECE_TYPE_CNT - 2]; PLAYER_CNT] = [
             [w_pair_bish, w_pawn_count, w_knight_count, w_bishop_count, w_rook_count, w_queen_count],
             [b_pair_bish, b_pawn_count, b_knight_count, b_bishop_count, b_rook_count, b_queen_count]];
 
@@ -137,7 +137,7 @@ impl Material {
     }
 }
 
-fn imbalance<P: PlayerTrait>(piece_counts: &[[u8; PIECE_TYPE_CNT]; PLAYER_CNT]) -> i32 {
+fn imbalance<P: PlayerTrait>(piece_counts: &[[u8; PIECE_TYPE_CNT - 2]; PLAYER_CNT]) -> i32 {
     let mut bonus: i32 = 0;
 
     for pt1 in 0..6 {

--- a/pleco_engine/src/tables/mod.rs
+++ b/pleco_engine/src/tables/mod.rs
@@ -10,6 +10,7 @@ use std::ptr::NonNull;
 use std::heap::{Alloc, Layout, Heap};
 use std::mem;
 use std::ptr;
+use std::ops::*;
 
 pub mod prelude {
     // easier exporting :)
@@ -25,8 +26,8 @@ pub mod prelude {
 // TODO: Create 3DBoard using const generics: https://github.com/rust-lang/rust/issues/44580
 
 
-pub trait StatBoard<T>: Sized
-    where T: Copy + Clone + Sized {
+pub trait StatBoard<T, IDX>: Sized + IndexMut<IDX, Output=T>
+    where T: Copy + Clone + Sized, {
 
     const FILL: T;
 
@@ -50,28 +51,27 @@ pub trait StatBoard<T>: Sized
     }
 }
 
-pub trait NumStatBoard: StatBoard<i16> {
+pub trait NumStatBoard<IDX>: StatBoard<i16,IDX>
+{
     const D: i16;
-    fn update(entry: &mut i16, bonus: i16) {
+    fn update(&mut self, idx: IDX, bonus: i16) {
         assert!(bonus.abs() <= Self::D); // Ensure range is [-32 * D, 32 * D]
+        let entry = self.index_mut(idx);
         *entry += bonus * 32 - (*entry) * bonus.abs() / Self::D;
     }
 }
 
-pub trait NumStatCube: StatBoard<i16> {
+
+pub trait NumStatCube<IDX>: StatBoard<i16,IDX> {
     const D: i16;
     const W: i16;
-    fn update(entry: &mut i16, bonus: i16) {
+    fn update(&mut self, idx: IDX, bonus: i16) {
         assert!(bonus.abs() <= Self::D);
-
+        let entry = self.index_mut(idx);
         *entry += bonus * Self::W - (*entry) * bonus.abs() / Self::D;
         assert!((*entry).abs() <= Self::D * Self::W);
     }
 }
-
-//impl StatBoard<i16> where {
-//
-//}
 
 // TODO: Performance increase awaiting with const generics: https://github.com/rust-lang/rust/issues/44580
 

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -374,7 +374,7 @@ impl PawnEntry {
         self.pawns_on_squares[P::player() as usize][Player::White as usize] = board.count_piece(P::player(), PieceType::P) - pawns_on_dark;
 
         while let Some(s) = p1.pop_some_lsb() {
-            assert_eq!(board.piece_at_sq(s).piece(), PieceType::P);
+            assert_eq!(board.piece_at_sq(s).type_of(), PieceType::P);
 
             let f: File = s.file();
 

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -374,7 +374,7 @@ impl PawnEntry {
         self.pawns_on_squares[P::player() as usize][Player::White as usize] = board.count_piece(P::player(), PieceType::P) - pawns_on_dark;
 
         while let Some(s) = p1.pop_some_lsb() {
-            assert_eq!(board.piece_at_sq(s).unwrap(), PieceType::P);
+            assert_eq!(board.piece_at_sq(s).piece(), PieceType::P);
 
             let f: File = s.file();
 


### PR DESCRIPTION
`pleco` changes:
- Updated to 0.3.11
- Documentation updates.

`pleco_engine` changes
- `StatBoard` now requires a `IndexMut` to function.
- Stub methods for actually using the `StatBoard`s inside the search.