### PR TITLE
Significant Eval improvements, Eval tracing, Reductions & Pruning for the main search.

### DIFF
--- a/pleco/src/board/castle_rights.rs
+++ b/pleco/src/board/castle_rights.rs
@@ -104,7 +104,7 @@ impl Castling {
     #[inline]
     pub fn player_can_castle(&self, player: Player) -> Castling {
         Castling {
-            bits: self.bits & (Castling::WHITE_ALL.bits << (2 * player as u16))
+            bits: self.bits & (Castling::WHITE_ALL.bits >> (2 * player as u16))
         }
     }
 

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -1603,6 +1603,14 @@ impl Board {
         self.state.nonpawn_material[player as usize]
     }
 
+    /// Returns the current non-pawn material value for both players.
+    #[inline(always)]
+    pub fn non_pawn_material_all(&self) -> Value {
+        self.state.nonpawn_material[Player::White as usize]
+            + self.state.nonpawn_material[Player::Black as usize]
+    }
+
+
     //  ------- CHECKING  -------
 
     /// Returns if current side to move is in check.

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -1538,6 +1538,12 @@ impl Board {
         self.state.pinners_king[player as usize]
     }
 
+    /// Returns the raw castling rights bits of the board.
+    #[inline(always)]
+    pub fn castling_bits(&self) -> u8 {
+        self.state.castling.bits()
+    }
+
     /// Return if a player has the possibility of castling for a given CastleType.
     /// This does not ensure a castling is possible for the player, just that the player
     /// has the castling-right available.
@@ -1816,6 +1822,19 @@ impl Board {
             }
         }
         true
+    }
+
+    /// Returns if the board contains only two bishops, one for each color, and each being
+    /// on different squares.
+    #[inline(always)]
+    pub fn opposite_bishops(&self) -> bool {
+        self.piece_counts[Player::White as usize][PieceType::B as usize] == 1
+        && self.piece_counts[Player::Black as usize][PieceType::B as usize] == 1
+        && {
+            let w_bishop = self.bbs_player[Player::White as usize] & self.bbs[PieceType::B as usize];
+            let b_bishop = self.bbs_player[Player::Black as usize] & self.bbs[PieceType::B as usize];
+            w_bishop.to_sq().opposite_colors(b_bishop.to_sq())
+        }
     }
 
     /// Checks if a move is an advanced pawn push, meaning it passes into enemy territory.

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -16,6 +16,7 @@ pub mod score;
 use self::bit_twiddles::*;
 use self::masks::*;
 use self::sq::SQ;
+use self::bitboard::BitBoard;
 
 use std::fmt;
 use std::mem;
@@ -653,6 +654,11 @@ impl File {
             other as u8 - self as u8
         }
     }
+
+    /// Returns the file `BitBoard`.
+    pub fn bb(self) -> BitBoard {
+        BitBoard(file_bb(self as u8))
+    }
 }
 
 impl Not for File {
@@ -688,6 +694,11 @@ impl Rank {
         } else {
             other as u8 - self as u8
         }
+    }
+
+    /// Returns the rank `BitBoard`.
+    pub fn bb(self) -> BitBoard {
+        BitBoard(rank_bb(self as u8))
     }
 }
 

--- a/pleco/src/core/score.rs
+++ b/pleco/src/core/score.rs
@@ -4,6 +4,7 @@
 //! the first to determine the mid-game score, and the second to determine the end-game score.
 
 use std::ops::*;
+use std::fmt;
 
 /// Type for `i16` to determine the `Value` of an evaluation.
 pub type Value = i32;
@@ -67,6 +68,20 @@ impl Score {
     /// Returns the end-game score.
     pub fn eg(self) -> Value {
         self.1
+    }
+
+    /// Gives the value of the score in centi-pawns
+    pub fn centipawns(self) -> (f64, f64) {
+        let mg: f64 = self.mg() as f64 / PAWN_EG as f64;
+        let eg: f64 = self.eg() as f64 / PAWN_EG as f64;
+        (mg, eg)
+    }
+}
+
+impl fmt::Display for Score {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (mg, eg) = self.centipawns();
+        write!(f, "{:5.2} {:5.2}",mg, eg)
     }
 }
 

--- a/pleco/src/core/sq.rs
+++ b/pleco/src/core/sq.rs
@@ -257,6 +257,13 @@ impl SQ {
     pub fn flip(self) -> SQ {
         SQ(self.0 ^ 0b111000)
     }
+
+    /// Determines if two squares are on opposite colors.
+    #[inline(always)]
+    pub fn opposite_colors(self, other: SQ) -> bool {
+        let s: u8 = self.0 as u8 ^ other.0 as u8;
+        ((s >> 3) ^ s) & 1 != 0
+    }
 }
 
 // constants

--- a/pleco_engine/benches/eval_benches.rs
+++ b/pleco_engine/benches/eval_benches.rs
@@ -18,7 +18,8 @@ fn bench_100_pawn_evals(b: &mut Bencher, boards: &Vec<Board>) {
         let mut score: i64 = 0;
         for board in boards.iter() {
             let entry: &mut PawnEntry = black_box(t.probe(board));
-            score += black_box(entry.pawns_score()).0 as i64;
+            score += black_box(entry.pawns_score(Player::White)).0 as i64;
+            score += black_box(entry.pawns_score(Player::Black)).0 as i64;
         }
     })
 }
@@ -32,7 +33,8 @@ fn bench_100_pawn_king_evals(b: &mut Bencher,  boards: &Vec<Board>) {
         let mut score: i64 = 0;
         for board in boards.iter() {
             let entry: &mut PawnEntry = black_box(t.probe(board));
-            score += black_box(entry.pawns_score()).0 as i64;
+            score += black_box(entry.pawns_score(Player::White)).0 as i64;
+            score += black_box(entry.pawns_score(Player::Black)).0 as i64;
             score +=  black_box(entry.king_safety::<WhiteType>(&board, board.king_sq(Player::White))).0 as i64;
         }
     })

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -11,6 +11,7 @@ use pleco::helper::prelude;
 
 
 use threadpool;
+use search;
 
 pub const MAX_PLY: u16 = 126;
 pub const THREAD_STACK_SIZE: usize = MAX_PLY as usize + 7;
@@ -37,6 +38,7 @@ pub fn init_globals() {
         compiler_fence(Ordering::SeqCst);
         lazy_static::initialize(&TT_TABLE); // Transposition Table
         threadpool::init_threadpool();  // Make Threadpool
+        search::init();
     });
 }
 

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -63,22 +63,6 @@ impl PVNode for NonPV {
     }
 }
 
-pub trait CheckState {
-    fn in_check() -> bool;
-}
-
-
-pub struct InCheck {}
-pub struct NoCheck {}
-
-impl CheckState for InCheck {
-    fn in_check() -> bool { true}
-}
-
-impl CheckState for NoCheck {
-    fn in_check() -> bool { false}
-}
-
 
 #[cfg(test)]
 mod tests {

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -13,6 +13,8 @@ use TT_TABLE;
 use consts::*;
 use threadpool::threadpool;
 
+use search::eval::Evaluation;
+
 use num_cpus;
 
 // --------- STATIC VARIABLES
@@ -74,13 +76,14 @@ impl PlecoSearcher {
                     } else {
                         println!("unable to parse board");
                     }
-                }
+                },
                 "go" => self.uci_go(&args[1..]),
                 "quit" => {
                     self.halt();
                     break;
                 },
                 "stop" => self.halt(),
+                "eval" => Evaluation::trace(&self.board),
                 _ => print!("Unknown Command: {}",full_command)
             }
             self.apply_all_options();

--- a/pleco_engine/src/root_moves/mod.rs
+++ b/pleco_engine/src/root_moves/mod.rs
@@ -16,7 +16,7 @@ pub struct RootMove {
     pub score: i32,
     pub prev_score: i32,
     pub bit_move: BitMove,
-    pub depth_reached: u16,
+    pub depth_reached: i16,
 }
 
 
@@ -35,7 +35,7 @@ impl RootMove {
     /// Places the current score into the previous_score field, and then updates
     /// the score and depth.
     #[inline]
-    pub fn rollback_insert(&mut self, score: i32, depth: u16) {
+    pub fn rollback_insert(&mut self, score: i32, depth: i16) {
         self.prev_score = self.score;
         self.score = score;
         self.depth_reached = depth;
@@ -43,7 +43,7 @@ impl RootMove {
 
     /// Inserts a score and depth.
     #[inline]
-    pub fn insert(&mut self, score: i32, depth: u16) {
+    pub fn insert(&mut self, score: i32, depth: i16) {
         self.score = score;
         self.depth_reached = depth;
     }

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -99,7 +99,7 @@ impl RootMoveList {
     }
 
     #[inline]
-    pub fn insert_score_depth(&mut self, index: usize, score: i32, depth: u16) {
+    pub fn insert_score_depth(&mut self, index: usize, score: i32, depth: i16) {
         unsafe {
             let rm: &mut RootMove = self.get_unchecked_mut(index);
             rm.score = score;

--- a/pleco_engine/src/tables/material.rs
+++ b/pleco_engine/src/tables/material.rs
@@ -51,8 +51,11 @@ impl MaterialEntry {
     pub fn score(&self) -> Score {
         Score(self.value, self.value)
     }
-}
 
+    pub fn scale_factor(&self, player: Player) -> u8 {
+        self.factor[player as usize]
+    }
+}
 
 
 pub struct Material {
@@ -86,7 +89,7 @@ impl Material {
         }
 
         entry.key = key;
-        entry.factor = [0; PLAYER_CNT];
+        entry.factor = [SCALE_FACTOR_NORMAL; PLAYER_CNT];
 
         let npm_w: Value = board.non_pawn_material(Player::White);
         let npm_b: Value = board.non_pawn_material(Player::Black);
@@ -107,13 +110,20 @@ impl Material {
         let b_queen_count: u8 =  board.count_piece(Player::Black, PieceType::Q);
 
         if w_pawn_count == 0 && npm_w - npm_b <= BISHOP_MG {
-            entry.factor[Player::White as usize] = if npm_w < ROOK_MG { SCALE_FACTOR_DRAW
-            } else if npm_b <= BISHOP_MG { 4 } else { 14 };
+            entry.factor[Player::White as usize] = if npm_w < ROOK_MG {
+                SCALE_FACTOR_DRAW
+            } else if npm_b <= BISHOP_MG {
+                4
+            } else { 14 };
         }
 
         if b_pawn_count == 0 && npm_b - npm_w <= BISHOP_MG {
-            entry.factor[Player::Black as usize] = if npm_b < ROOK_MG { SCALE_FACTOR_DRAW
-            } else if npm_w <= BISHOP_MG { 4 } else { 14 };
+            entry.factor[Player::Black as usize] = if npm_b < ROOK_MG {
+                SCALE_FACTOR_DRAW
+            } else if
+                npm_w <= BISHOP_MG {
+                4
+            } else { 14 };
         }
 
         if w_pawn_count == 1 && npm_w - npm_b <= BISHOP_MG {


### PR DESCRIPTION
`pleco` changes:
- Fixed bug with `Castling::player_can_castle()` returning incorrect results
- Added `Board::castling_bits()` to return the raw u8 of the castling
- Added `Board::non_pawn_material_all()` to return the sum of both player's npm
- Added `Board::opposite_bishops()` to check if the only non Pawn/King pieces are two bishops of opposite players, being on opposite square types.
- `File::bb()` and Rank::bb()` for returning the BitBoards of Files/Ranks
- `Score::centipawns()` for returning the value of a score in centipawns
- impl `Display` for `Score`.
- Added `SQ::opoosite_colors(other: SQ)`

`pleco_engine` changes
- Removed the `InCheck` parameter from qsearch
- Simplified entry into qsearch
- `depth` is now a i16
- `Eval` changes:
    - Connectivity and Queen Slider bonus's
    - Completed the tracing function, added to the `Eval` function as a method.
    - Added an `EvaluationInner` to distinguish internal vs. External access to evaluation.
    - removed `attacked_by_all` and `attacked_by_queen_diagonal` from `EvaluationInner` 
    - Added a `Evaluation::scale_factor()` method to further scale between mid and end-game scores
    - Significant bug fixes resulting in a more accurate evaluation.
- Search algorithm changes:
    - Altered timing parameters
    - Added an `excluded_move` search for pruning the possibility of a better non-tt move.
    - `tt_move` now defaults to the first root move when at root.
    - Added `improving` factor to futility pruning.
    - Singular Extensions 
    - Shallow depth pruning
    - Reduced Depth LMR Search
    - Reductions / Extensions
    - Added `cut_node` and `ski_early_pruning` fields for `search`
- `Material` changes:
    - Fixed bug where the scale factors would default to zero, instead of the normal scale factor
- `PawnEntry` changes:
    - Separated out the score to be per player.
    - Bug fixes
- Added startup generated `Search` tables