### PR TITLE
Update `pleco` to 0.4.1 and `pleco_engine` to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ UCI (Universal Chess Interface) compatible engine.
 The overall goal for this project is to utilize the efficiency of Rust to create a Chess AI matching the speed of modern chess engines.
 For the engine, the majority of the code is a direct port of Stockfish's C++ code. See [their website](https://stockfishchess.org/) for
 more information about the engine. As such, the credit for all of the advanced algorithms used for searching, evaluation,
-and many others, go directly to the maintainers and authors of Stockfish. This project is simply for speed comparisons
+and many others, go directly to the maintainers and authors of Stockfish. This project is for speed comparisons
 between the two languages, as well as for educational purposes.
 
 - [Documentation](https://docs.rs/pleco), [crates.io](https://crates.io/crates/pleco) for library functionality

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -78,6 +78,7 @@
 #![feature(pointer_methods)]
 #![feature(cfg_target_feature, target_feature)]
 #![feature(stdsimd)]
+#![feature(nonnull_cast)]
 
 #![allow(dead_code)]
 

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco_engine"
-version = "0.1.1" # Reminder to change in ./engine.rs
+version = "0.1.2" # Reminder to change in ./engine.rs
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"
@@ -67,7 +67,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.4.0" }
+pleco = { path = "../pleco", version = "0.4.1" }
 clippy = {version = "0.0.191", optional = true}
 chrono = "0.4.1"
 rand = "0.4.2"

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -1,5 +1,5 @@
 //! Constant values and static structures.
-use std::heap::{Alloc, Layout, Heap};
+use std::heap::{Alloc, Layout, Global};
 
 use std::ptr::{NonNull, self};
 use std::sync::atomic::AtomicBool;
@@ -52,10 +52,10 @@ pub fn init_globals() {
 fn init_tt() {
     unsafe {
         let layout = Layout::new::<TranspositionTable>();
-        let result = Heap.alloc_zeroed(layout);
+        let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TranspositionTable = match result {
-            Ok(ptr) => ptr as *mut TranspositionTable,
-            Err(err) => Heap.oom(err),
+            Ok(ptr) => ptr.cast().as_ptr() as *mut TranspositionTable,
+            Err(_err) => Global.oom(),
         };
         ptr::write(new_ptr, TranspositionTable::new(DEFAULT_TT_SIZE));
         TT_TABLE = NonNull::new_unchecked(new_ptr);
@@ -65,10 +65,10 @@ fn init_tt() {
 fn init_timer() {
     unsafe {
         let layout = Layout::new::<TimeManager>();
-        let result = Heap.alloc_zeroed(layout);
+        let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TimeManager = match result {
-            Ok(ptr) => ptr as *mut TimeManager,
-            Err(err) => Heap.oom(err),
+            Ok(ptr) => ptr.cast().as_ptr() as *mut TimeManager,
+            Err(_err) => Global.oom(),
         };
         ptr::write(new_ptr, TimeManager::uninitialized());
         TIMER = NonNull::new_unchecked(new_ptr);

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -20,7 +20,7 @@ use num_cpus;
 
 pub static ID_NAME: &str = "Pleco";
 pub static ID_AUTHORS: &str = "Stephen Fleischman";
-pub static VERSION: &str = "0.1.1";
+pub static VERSION: &str = "0.1.2";
 
 #[derive(PartialEq)]
 enum SearchType {

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(fused)]
 #![feature(const_fn)]
 #![feature(box_into_raw_non_null)]
+#![feature(nonnull_cast)]
 
 //#![crate_type = "staticlib"]
 


### PR DESCRIPTION
Fixes compilation errors due to the recent changes in nightly rust.