### PR TITLE
Fixes for nightly changes, update pleco to 0.4.2 and pleco_engine to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rpath = false
 debug-assertions = false
 codegen-units = 1
 lto = true
-panic = "unwind"
+panic = "abort"
 
 [profile.bench]
 opt-level = 3
@@ -20,7 +20,6 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
-panic = "abort"
 
 [profile.test]
 opt-level = 3
@@ -28,8 +27,7 @@ debug = true
 rpath = false
 debug-assertions = true
 codegen-units = 4
-panic = "unwind"
 
 
 [dependencies]
-clippy = {version = "0.0.174", default-features = false, optional = true}
+clippy = {version = "0.0.200", default-features = false, optional = true}

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["chess","ai","engine","game","gaming"]
 license = "MIT"
 categories = ["games","game-engines"]
 repository = "https://github.com/sfleischman105/Pleco"
+autobenches = false
 
 
 include = [
@@ -47,28 +48,17 @@ debug = false
 lto = true
 debug-assertions = false
 codegen-units = 1
-panic = "abort"
 
 [profile.test]
 opt-level = 3
 debug = true
 debug-assertions = true
 codegen-units = 4
-panic = "unwind"
-
-[profile.doc]
-opt-level = 0
-debug = 2
-rpath = false
-lto = false
-debug-assertions = true
-codegen-units = 1
-panic = "unwind"
 
 
 [dependencies]
-clippy = {version = "0.0.191", optional = true}
-bitflags = "1.0.1"
+clippy = {version = "0.0.200", optional = true}
+bitflags = "1.0.3"
 rand = "0.4.2"
 rayon = "1.0.1"
 num_cpus = "1.8.0"
@@ -78,7 +68,7 @@ unreachable = "1.0.0"
 
 [dependencies.lazy_static]
 version = "1.0.0"
-features = ["nightly"]
+#features = ["nightly"]
 
 [features]
 default = []

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -86,9 +86,7 @@ impl fmt::Debug for FenBuildError {
     }
 }
 
-struct PreFetchDummy {
-
-}
+struct PreFetchDummy {}
 
 impl PreFetchable for PreFetchDummy {
     fn prefetch(&self, _key: u64) {}

--- a/pleco/src/board/perft.rs
+++ b/pleco/src/board/perft.rs
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(193690690, perft(&b,5));
     }
 
-    // THis passes, but we're gonna ignore it as it takes a long time to use.
+    // This passes, but we're gonna ignore it as it takes a long time to use.
     #[ignore]
     #[test]
     fn perft_kiwipete_all() {

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -76,7 +76,6 @@
 #![feature(allocator_api)]
 #![feature(const_fn)]
 #![feature(pointer_methods)]
-#![feature(cfg_target_feature, target_feature)]
 #![feature(stdsimd)]
 #![feature(nonnull_cast)]
 

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -35,7 +35,7 @@
 
 use std::ptr::NonNull;
 use std::mem;
-use std::heap::{Alloc, Layout, Global};
+use std::heap::{Alloc, Layout, Global, oom};
 use std::cmp::min;
 use std::cell::UnsafeCell;
 
@@ -484,7 +484,7 @@ fn alloc_room(size: usize) -> NonNull<Cluster> {
 
         let new_ptr = match ptr {
             Ok(ptr) => ptr.cast(),
-            Err(_err) => Global.oom(),
+            Err(_err) => oom(),
         };
         new_ptr
     }

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["chess","ai","engine","game","uci"]
 license = "MIT"
 categories = ["games","game-engines","command-line-utilities"]
 repository = "https://github.com/sfleischman105/Pleco"
-
+autobenches = false
 
 include = [
     "src/*",
@@ -43,22 +43,12 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
-panic = "abort"
 
 [profile.test]
 opt-level = 3
 debug = true
 debug-assertions = true
 codegen-units = 1
-panic = "unwind"
-
-[profile.doc]
-opt-level = 0
-debug = true
-lto = false
-debug-assertions = true
-codegen-units = 4
-panic = "unwind"
 
 [lib]
 name = "pleco_engine"
@@ -68,7 +58,7 @@ doctest = true
 
 [dependencies]
 pleco = { path = "../pleco", version = "0.4.1" }
-clippy = {version = "0.0.191", optional = true}
+clippy = {version = "0.0.200", optional = true}
 chrono = "0.4.1"
 rand = "0.4.2"
 num_cpus = "1.8.0"
@@ -87,7 +77,8 @@ doc = false
 
 [dev-dependencies]
 criterion = {  version = '0.2.2', default-features = false, features=['real_blackbox'] }
-lazy_static = {version = "1.0.0", features = ["nightly"]}
+lazy_static = {version = "1.0.0"}
+#lazy_static = {version = "1.0.0", features = ["nightly"]}
 
 [[bench]]
 name = "bench_engine_main"

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco_engine"
-version = "0.1.2" # Reminder to change in ./engine.rs
+version = "0.1.3" # Reminder to change in ./engine.rs
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"
@@ -57,7 +57,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.4.1" }
+pleco = { path = "../pleco", version = "0.4.2" }
 clippy = {version = "0.0.200", optional = true}
 chrono = "0.4.1"
 rand = "0.4.2"

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -1,5 +1,5 @@
 //! Constant values and static structures.
-use std::heap::{Alloc, Layout, Global};
+use std::heap::{Alloc, Layout, Global, oom};
 
 use std::ptr::{NonNull, self};
 use std::sync::atomic::AtomicBool;
@@ -55,7 +55,7 @@ fn init_tt() {
         let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TranspositionTable = match result {
             Ok(ptr) => ptr.cast().as_ptr() as *mut TranspositionTable,
-            Err(_err) => Global.oom(),
+            Err(_err) => oom(),
         };
         ptr::write(new_ptr, TranspositionTable::new(DEFAULT_TT_SIZE));
         TT_TABLE = NonNull::new_unchecked(new_ptr);
@@ -68,7 +68,7 @@ fn init_timer() {
         let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TimeManager = match result {
             Ok(ptr) => ptr.cast().as_ptr() as *mut TimeManager,
-            Err(_err) => Global.oom(),
+            Err(_err) => oom(),
         };
         ptr::write(new_ptr, TimeManager::uninitialized());
         TIMER = NonNull::new_unchecked(new_ptr);

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -20,7 +20,7 @@ use num_cpus;
 
 pub static ID_NAME: &str = "Pleco";
 pub static ID_AUTHORS: &str = "Stephen Fleischman";
-pub static VERSION: &str = "0.1.2";
+pub static VERSION: &str = "0.1.3";
 
 #[derive(PartialEq)]
 enum SearchType {

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -1068,7 +1068,7 @@ impl Searcher {
                 }
 
                 if tt_value != NONE && correct_bound(tt_value, best_value, tt_entry.node_type()) {
-                    best_value == tt_value;
+                    best_value = tt_value;
                 }
             } else {
                 best_value = self.eval();

--- a/pleco_engine/src/tables/mod.rs
+++ b/pleco_engine/src/tables/mod.rs
@@ -7,7 +7,7 @@ pub mod capture_piece_history;
 pub mod butterfly;
 
 use std::ptr::NonNull;
-use std::heap::{Alloc, Layout, Global};
+use std::heap::{Alloc, Layout, Global, oom};
 use std::mem;
 use std::ptr;
 use std::ops::*;
@@ -141,7 +141,7 @@ impl<T: Sized + TableBaseConst> TableBase<T> {
         let ptr = Global.alloc_zeroed(Layout::array::<T>(T::ENTRY_COUNT).unwrap());
         let new_ptr = match ptr {
             Ok(ptr) => ptr.cast().as_ptr(),
-            Err(_err) => Global.oom(),
+            Err(_err) => oom(),
         };
         NonNull::new(new_ptr as *mut T).unwrap()
     }

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the ThreadPool and the individual Threads.
 
-use std::heap::{Alloc, Layout, Global};
+use std::heap::{Alloc, Layout, Global, oom};
 use std::sync::atomic::{AtomicBool,Ordering};
 use std::thread::{JoinHandle,self};
 use std::sync::{Once, ONCE_INIT};
@@ -42,7 +42,7 @@ pub fn init_threadpool() {
                 let result = Global.alloc_zeroed(layout);
                 let new_ptr: *mut ThreadPool = match result {
                     Ok(ptr) => ptr.cast().as_ptr() as *mut ThreadPool,
-                    Err(_err) => Global.oom(),
+                    Err(_err) => oom(),
                 };
                 ptr::write(new_ptr, ThreadPool::new());
                 THREADPOOL = NonNull::new_unchecked(new_ptr);
@@ -141,7 +141,7 @@ impl ThreadPool {
             let result = Global.alloc_zeroed(layout);
             let new_ptr: *mut Searcher = match result {
                 Ok(ptr) => ptr.cast().as_ptr() as *mut Searcher,
-                Err(_err) => Global.oom(),
+                Err(_err) => oom(),
             };
             ptr::write(new_ptr, Searcher::new(len, cond));
             self.threads.push(UnsafeCell::new(new_ptr));


### PR DESCRIPTION
A quick patch for the recent changes in nightly.

`pleco` updated to 0.4.2 and `pleco_engine` updated to 0.1.3.