### PR TITLE
Nightly Alloc breakage fixes, global TT/Thread Pool now in fixed memory locations

### DIFF
--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -480,11 +480,12 @@ unsafe fn cluster_first_entry(cluster: *mut Cluster) -> *mut Entry {
 #[inline]
 fn alloc_room(size: usize) -> NonNull<Cluster> {
     unsafe {
-        let ptr = Global.alloc_zeroed(Layout::array::<Cluster>(size).unwrap());
+        let layout = Layout::array::<Cluster>(size).unwrap();
+        let ptr = Global.alloc_zeroed(layout);
 
         let new_ptr = match ptr {
             Ok(ptr) => ptr.cast(),
-            Err(_err) => oom(),
+            Err(_err) => oom(layout),
         };
         new_ptr
     }

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco_engine"
-version = "0.1.3" # Reminder to change in ./engine.rs
+version = "0.1.3"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -55,7 +55,7 @@ fn init_tt() {
         let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TranspositionTable = match result {
             Ok(ptr) => ptr.cast().as_ptr() as *mut TranspositionTable,
-            Err(_err) => oom(),
+            Err(_err) => oom(layout),
         };
         ptr::write(new_ptr, TranspositionTable::new(DEFAULT_TT_SIZE));
         TT_TABLE = NonNull::new_unchecked(new_ptr);
@@ -68,7 +68,7 @@ fn init_timer() {
         let result = Global.alloc_zeroed(layout);
         let new_ptr: *mut TimeManager = match result {
             Ok(ptr) => ptr.cast().as_ptr() as *mut TimeManager,
-            Err(_err) => oom(),
+            Err(_err) => oom(layout),
         };
         ptr::write(new_ptr, TimeManager::uninitialized());
         TIMER = NonNull::new_unchecked(new_ptr);

--- a/pleco_engine/src/engine.rs
+++ b/pleco_engine/src/engine.rs
@@ -20,7 +20,7 @@ use num_cpus;
 
 pub static ID_NAME: &str = "Pleco";
 pub static ID_AUTHORS: &str = "Stephen Fleischman";
-pub static VERSION: &str = "0.1.3";
+pub static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(PartialEq)]
 enum SearchType {

--- a/pleco_engine/src/tables/mod.rs
+++ b/pleco_engine/src/tables/mod.rs
@@ -138,10 +138,11 @@ impl<T: Sized + TableBaseConst> TableBase<T> {
 
     // allocates space.
     unsafe fn alloc() -> NonNull<T> {
-        let ptr = Global.alloc_zeroed(Layout::array::<T>(T::ENTRY_COUNT).unwrap());
+        let layout = Layout::array::<T>(T::ENTRY_COUNT).unwrap();
+        let ptr = Global.alloc_zeroed(layout);
         let new_ptr = match ptr {
             Ok(ptr) => ptr.cast().as_ptr(),
-            Err(_err) => oom(),
+            Err(_err) => oom(layout),
         };
         NonNull::new(new_ptr as *mut T).unwrap()
     }

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -42,7 +42,7 @@ pub fn init_threadpool() {
                 let result = Global.alloc_zeroed(layout);
                 let new_ptr: *mut ThreadPool = match result {
                     Ok(ptr) => ptr.cast().as_ptr() as *mut ThreadPool,
-                    Err(_err) => oom(),
+                    Err(_err) => oom(layout),
                 };
                 ptr::write(new_ptr, ThreadPool::new());
                 THREADPOOL = NonNull::new_unchecked(new_ptr);
@@ -141,7 +141,7 @@ impl ThreadPool {
             let result = Global.alloc_zeroed(layout);
             let new_ptr: *mut Searcher = match result {
                 Ok(ptr) => ptr.cast().as_ptr() as *mut Searcher,
-                Err(_err) => oom(),
+                Err(_err) => oom(layout),
             };
             ptr::write(new_ptr, Searcher::new(len, cond));
             self.threads.push(UnsafeCell::new(new_ptr));

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -23,15 +23,20 @@ use consts::*;
 
 const KILOBYTE: usize = 1000;
 const THREAD_STACK_SIZE: usize = 18000 * KILOBYTE;
-
-// The Global threadpool!
 const POOL_SIZE: usize = mem::size_of::<ThreadPool>();
+
+// An object that is the same size as a thread pool.
 type DummyThreadPool = [u8; POOL_SIZE];
 
+// The Global threadpool! Yes, this is *technically* an array the same
+// size as a ThreadPool object. This is a cheap hack to get a global value, as
+// Rust isn't particularily fond of mutable global statics.
 pub static mut THREADPOOL: DummyThreadPool = [0; POOL_SIZE];
 
+// ONCE for the Threadpool
 static THREADPOOL_INIT: Once = ONCE_INIT;
 
+// Initializes the threadpool, called once on startup.
 pub fn init_threadpool() {
     THREADPOOL_INIT.call_once(|| {
         unsafe {


### PR DESCRIPTION
Changes:
- `VERSION` String is a macro now, referencing the current cargo version.
- Modified Heap Allocations to use the new `Alloc` interface (for maybe the third time this month!).
- The global Thread Pool and TranspositionTable are in a fixed location in memory, rather than heap allocated. All previous references have been changed to directly accessing the value in memory. This provides a decent speed-up.

