### PR TITLE
Update versions, Fix nightly breakage, slight optimizations

### DIFF
--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast chess library."
 homepage = "https://github.com/sfleischman105/Pleco"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -59,7 +59,7 @@ codegen-units = 4
 [dependencies]
 clippy = {version = "0.0.200", optional = true}
 bitflags = "1.0.3"
-rand = "0.5.0"
+rand = "0.5.2"
 rayon = "1.0.1"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -64,7 +64,6 @@ rayon = "1.0.1"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
 mucow = "0.1.0"
-unreachable = "1.0.0"
 
 [dependencies.lazy_static]
 version = "1.0.0"

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -12,6 +12,7 @@
 use std::option::*;
 use std::{fmt, char,num};
 use std::cmp::{PartialEq,max,min};
+use std::hint::unreachable_unchecked;
 
 use rand;
 
@@ -1947,7 +1948,7 @@ impl Board {
                     PieceType::Q => {
                         queen_moves(self.occupied() ^ src_bb, dst)
                     }
-                    _ => unreachable!(),
+                    _ => unsafe { unreachable_unchecked() }
                 };
                 (attacks_bb & opp_king_sq.to_bb()).is_not_empty()
             }

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -54,6 +54,7 @@
 use std::mem;
 use std::ptr;
 use std::ops::Index;
+use std::hint::unreachable_unchecked;
 
 use board::*;
 
@@ -253,7 +254,7 @@ impl<'a, MP: MVPushable> InnerMoveGen<'a, MP>
             GenTypes::NonEvasions => !self.us_occ,
             GenTypes::Captures => self.them_occ,
             GenTypes::Quiets => !(self.us_occ | self.them_occ),
-            _ => unreachable!()
+            _ => unsafe { unreachable_unchecked() }
         };
 
         self.generate_all::<L, G, P>(target);

--- a/pleco/src/core/bitboard.rs
+++ b/pleco/src/core/bitboard.rs
@@ -39,6 +39,7 @@ use std::fmt;
 /// bit maps to a specific square. Used for mapping occupancy, where '1' represents
 /// a piece being at that index's square, and a '0' represents a lack of a piece.
 #[derive(Copy, Clone, Default, Hash, PartialEq, Eq, Debug)]
+#[repr(transparent)]
 pub struct BitBoard(pub u64);
 
 impl_bit_ops!(BitBoard, u64);

--- a/pleco/src/core/bitboard.rs
+++ b/pleco/src/core/bitboard.rs
@@ -34,6 +34,7 @@ use super::Player;
 use std::mem;
 use std::ops::*;
 use std::fmt;
+use std::hint::unreachable_unchecked;
 
 /// A `BitBoard` is simply a 64 bit long integer where each
 /// bit maps to a specific square. Used for mapping occupancy, where '1' represents
@@ -374,7 +375,7 @@ impl RandBitBoard {
                 RandAmount::Sparse => self.prng.sparse_rand(),   // Average 8 bits
                 RandAmount::VerySparse => self.prng.sparse_rand() & (self.prng.rand() | self.prng.rand()), // Average 6 bits
                 RandAmount::ExtremelySparse => self.prng.sparse_rand() & self.prng.rand(),   // Average 4 bits
-                RandAmount::Singular => unreachable!()
+                RandAmount::Singular => unsafe {unreachable_unchecked()}
             };
             let count = popcount64(num) as u16;
             if count >= self.min && count <= self.max {

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -117,7 +117,7 @@ pub enum MoveFlag {
 
 /// A Subset of `MoveFlag`, used to determine the overall classification of a move.
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[repr(u16)]
+#[repr(u8)]
 pub enum MoveType {
     /// The move is "Normal", So its not a castle, promotion, or en-passant.
     Normal = 0,    //0b000x

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -84,6 +84,7 @@ const SP_MASK: u16      = 0b0011_000000_000000;
 /// A `BitMove` should never be created directly, but rather instigated with a `PreMoveInfo`. This is because
 /// the bits are in a special order, and manually creating moves risks creating an invalid move.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(transparent)]
 pub struct BitMove {
     data: u16,
 }

--- a/pleco/src/core/sq.rs
+++ b/pleco/src/core/sq.rs
@@ -64,6 +64,7 @@ use std::mem::transmute;
 
 /// Represents a singular square of a chessboard.
 #[derive(Copy, Clone, Default, Hash, PartialEq, PartialOrd, Eq, Debug)]
+#[repr(transparent)]
 pub struct SQ(pub u8);
 
 impl_bit_ops!(SQ, u8);

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -90,7 +90,6 @@ extern crate rand;
 extern crate rayon;
 extern crate prefetch;
 extern crate mucow;
-extern crate unreachable;
 
 pub mod core;
 pub mod board;

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -59,8 +59,8 @@ doctest = true
 [dependencies]
 pleco = { path = "../pleco", version = "0.4.2" }
 clippy = {version = "0.0.200", optional = true}
-chrono = "0.4.2"
-rand = "0.5.0"
+chrono = "0.4.4"
+rand = "0.5.2"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
 crossbeam-utils = "0.4.0"

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pleco_engine"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Stephen Fleischman <stephenf@cs.washington.edu>"]
 description = "A blazingly-fast Chess AI."
 homepage = "https://github.com/sfleischman105/Pleco"
@@ -57,7 +57,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.4.2" }
+pleco = { path = "../pleco", version = "0.4.3" }
 clippy = {version = "0.0.200", optional = true}
 chrono = "0.4.4"
 rand = "0.5.2"


### PR DESCRIPTION
Updated `pleco` to 0.4.3 and `pleco_engine` to 0.1.4.

`pleco` changes:
- Added new 'unreachable_unchecked` hint, removing dependency on `unreachable` crate.
- Added `repr(transparent)` to `BitMove`, `Sq`, and `BitBoard`.
- Changed `MoveType` from a `u16` to `u8`.
- Fixed allocation issues.
- Updated dependencies.

`pleco_engine` changes:
- Fixed allocation issues.
- Updated dependencies.
