### PR TITLE
Dependencies Updates / Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [workspace]
 members = [
     "pleco",
-    "pleco_engine",
-]
+    "pleco_engine",]
+
+default-members = [
+    "pleco",
+    "pleco_engine",]
 
 [profile.release]
 opt-level = 3
@@ -27,7 +30,3 @@ debug = true
 rpath = false
 debug-assertions = true
 codegen-units = 4
-
-
-[dependencies]
-clippy = {version = "0.0.200", default-features = false, optional = true}

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -57,24 +57,19 @@ codegen-units = 4
 
 
 [dependencies]
-clippy = {version = "0.0.302", optional = true}
 bitflags = "1.0.4"
-rand = "0.6.1"
+rand = "0.6.5"
 rayon = "1.0.3"
-num_cpus = "1.9.0"
+num_cpus = "1.10.0"
 prefetch = "0.2.0"
 mucow = "0.1.0"
-
-[dependencies.lazy_static]
-version = "1.1.0"
-features = ["nightly"]
+lazy_static = "1.3.0"
 
 [features]
 default = []
-dev = ["clippy"]
 
 [dev-dependencies]
-criterion = { version = '0.2.7', default-features = false, features=['real_blackbox'] }
+criterion = { version = '0.2.10', default-features = false, features=['real_blackbox'] }
 
 [[bench]]
 name = "bench_main"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -66,7 +66,7 @@ prefetch = "0.2.0"
 mucow = "0.1.0"
 
 [dependencies.lazy_static]
-version = "1.1.0"   # 1.2.0
+version = "1.1.0"
 features = ["nightly"]
 
 [features]
@@ -74,7 +74,7 @@ default = []
 dev = ["clippy"]
 
 [dev-dependencies]
-criterion = { version = '0.2.4', default-features = false, features=['real_blackbox'] }
+criterion = { version = '0.2.7', default-features = false, features=['real_blackbox'] }
 
 [[bench]]
 name = "bench_main"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -59,14 +59,14 @@ codegen-units = 4
 [dependencies]
 clippy = {version = "0.0.302", optional = true}
 bitflags = "1.0.4"
-rand = "0.6.0"
-rayon = "1.0.2"
-num_cpus = "1.8.0"
+rand = "0.6.1"
+rayon = "1.0.3"
+num_cpus = "1.9.0"
 prefetch = "0.2.0"
 mucow = "0.1.0"
 
 [dependencies.lazy_static]
-version = "1.1.0"
+version = "1.1.0"   # 1.2.0
 features = ["nightly"]
 
 [features]

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -57,9 +57,9 @@ codegen-units = 4
 
 
 [dependencies]
-clippy = {version = "0.0.200", optional = true}
+clippy = {version = "0.0.302", optional = true}
 bitflags = "1.0.4"
-rand = "0.5.5"
+rand = "0.6.0"
 rayon = "1.0.2"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"

--- a/pleco/benches/board_benches.rs
+++ b/pleco/benches/board_benches.rs
@@ -37,8 +37,8 @@ fn bench_board_100_clone(c: &mut Criterion) {
 
 
 fn bench_find(c: &mut Criterion) {
+    lazy_static::initialize(&RAND_BOARDS);
     c.bench_function("Board find King SQ", |b| {
-        lazy_static::initialize(&RAND_BOARDS);
         b.iter(|| {
             black_box({
                 for board in RAND_BOARDS.iter() {
@@ -50,6 +50,7 @@ fn bench_find(c: &mut Criterion) {
 }
 
 fn bench_apply_100_move(c: &mut Criterion) {
+    lazy_static::initialize(&RAND_BOARDS);
     c.bench_function("Board Apply 100 Move",  |b| {
         let mut prng = PRNG::init(SEED);
         let mut board_move: Vec<(Board, BitMove)> = Vec::with_capacity(100);
@@ -72,6 +73,7 @@ fn bench_apply_100_move(c: &mut Criterion) {
 }
 
 fn bench_undo_100_move(c: &mut Criterion) {
+    lazy_static::initialize(&RAND_BOARDS);
     c.bench_function("Board Undo 100 Move", |b| {
         let mut boards: Vec<Board> = Vec::with_capacity(100);
         for board in RAND_BOARDS.iter() {

--- a/pleco/benches/bot_benches.rs
+++ b/pleco/benches/bot_benches.rs
@@ -7,7 +7,6 @@ use pleco::Board;
 use pleco::bot_prelude::*;
 use pleco::tools::Searcher;
 
-
 lazy_static! {
     pub static ref RAND_BOARDS: Vec<Board> = {
         let mut vec = Vec::new();

--- a/pleco/benches/lookup_benches.rs
+++ b/pleco/benches/lookup_benches.rs
@@ -98,7 +98,7 @@ fn multi_lookup_stutter(b: &mut Bencher) {
 
 criterion_group!(name = lookup_benches;
      config = Criterion::default()
-        .sample_size(100)
-        .warm_up_time(Duration::from_millis(1));
+        .sample_size(250)
+        .warm_up_time(Duration::from_millis(3));
     targets = lookup_tables
 );

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -56,13 +56,7 @@
 //! [`MoveList`]: core/move_list/struct.MoveList.html
 //! [`Board`]: board/struct.Board.html
 #![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", allow(inline_always))]
-#![cfg_attr(feature="clippy", allow(unreadable_literal))]
-#![cfg_attr(feature="clippy", allow(large_digit_groups))]
-#![cfg_attr(feature="clippy", allow(cast_lossless))]
-#![cfg_attr(feature="clippy", allow(doc_markdown))]
-#![cfg_attr(feature="clippy", allow(inconsistent_digit_grouping))]
+//#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![cfg_attr(test, allow(dead_code))]
@@ -77,6 +71,7 @@
 #![feature(stdsimd)]
 #![feature(const_let)]
 #![feature(const_slice_len)]
+#![feature(alloc_layout_extra)]
 #![allow(dead_code)]
 
 #[macro_use]

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -55,8 +55,6 @@
 //!
 //! [`MoveList`]: core/move_list/struct.MoveList.html
 //! [`Board`]: board/struct.Board.html
-#![cfg_attr(feature="clippy", feature(plugin))]
-//#![cfg_attr(feature="clippy", plugin(clippy))]
 
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![cfg_attr(test, allow(dead_code))]
@@ -69,7 +67,6 @@
 #![feature(allocator_api)]
 #![feature(const_fn)]
 #![feature(stdsimd)]
-#![feature(const_let)]
 #![feature(const_slice_len)]
 #![feature(alloc_layout_extra)]
 #![allow(dead_code)]

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -58,12 +58,12 @@ doctest = true
 
 [dependencies]
 pleco = { path = "../pleco", version = "0.4.3" }
-clippy = {version = "0.0.200", optional = true}
-chrono = "0.4.5"
-rand = "0.5.5"
+clippy = {version = "0.0.302", optional = true}
+chrono = "0.4.6"
+rand = "0.6.0"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
-crossbeam-utils = "0.5.0"
+# crossbeam-utils = "0.5.0"  <- NOTE: allows unchecked spawning if doesn't stabilize
 
 [features]
 default = []

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -76,7 +76,7 @@ test = false
 doc = false
 
 [dev-dependencies]
-criterion = {  version = '0.2.4', default-features = false, features=['real_blackbox'] }
+criterion = {  version = '0.2.7', default-features = false, features=['real_blackbox'] }
 lazy_static = {version = "1.1.0", features = ["nightly"]}
 
 [[bench]]

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -58,16 +58,13 @@ doctest = true
 
 [dependencies]
 pleco = { path = "../pleco", version = "0.4.3" }
-clippy = {version = "0.0.302", optional = true}
 chrono = "0.4.6"
-rand = "0.6.1"
+rand = "0.6.5"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
-# crossbeam-utils = "0.5.0"  <- NOTE: allows unchecked spawning if doesn't stabilize
 
 [features]
 default = []
-dev = ["clippy"]
 
 [[bin]]
 name = "pleco"
@@ -76,8 +73,8 @@ test = false
 doc = false
 
 [dev-dependencies]
-criterion = {  version = '0.2.7', default-features = false, features=['real_blackbox'] }
-lazy_static = {version = "1.1.0", features = ["nightly"]}
+criterion = {  version = '0.2.10', default-features = false, features=['real_blackbox'] }
+lazy_static = {version = "1.3.0"}
 
 [[bench]]
 name = "bench_engine_main"

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -60,7 +60,7 @@ doctest = true
 pleco = { path = "../pleco", version = "0.4.3" }
 clippy = {version = "0.0.302", optional = true}
 chrono = "0.4.6"
-rand = "0.6.0"
+rand = "0.6.1"
 num_cpus = "1.8.0"
 prefetch = "0.2.0"
 # crossbeam-utils = "0.5.0"  <- NOTE: allows unchecked spawning if doesn't stabilize

--- a/pleco_engine/benches/eval_benches.rs
+++ b/pleco_engine/benches/eval_benches.rs
@@ -1,6 +1,6 @@
 
 use std::time::Duration;
-use criterion::{Criterion,black_box,Bencher,Fun};
+use criterion::{Criterion,black_box,Bencher,Fun, BatchSize};
 
 use pleco::{Board,Player};
 use pleco_engine::tables::pawn_table::{PawnEntry, PawnTable};
@@ -11,7 +11,7 @@ use pleco_engine::search::eval::Evaluation;
 
 fn bench_100_pawn_evals(b: &mut Bencher, boards: &Vec<Board>) {
 
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         PawnTable::new()
     }, |mut t| {
         #[allow(unused_variables)]
@@ -21,12 +21,12 @@ fn bench_100_pawn_evals(b: &mut Bencher, boards: &Vec<Board>) {
             score += black_box(entry.pawns_score(Player::White)).0 as i64;
             score += black_box(entry.pawns_score(Player::Black)).0 as i64;
         }
-    })
+    }, BatchSize::PerIteration)
 }
 
 
 fn bench_100_pawn_king_evals(b: &mut Bencher,  boards: &Vec<Board>) {
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         PawnTable::new()
     }, |mut t| {
         #[allow(unused_variables)]
@@ -37,11 +37,11 @@ fn bench_100_pawn_king_evals(b: &mut Bencher,  boards: &Vec<Board>) {
             score += black_box(entry.pawns_score(Player::Black)).0 as i64;
             score +=  black_box(entry.king_safety::<WhiteType>(&board, board.king_sq(Player::White))).0 as i64;
         }
-    })
+    }, BatchSize::PerIteration)
 }
 
 fn bench_100_material_eval(b: &mut Bencher,  boards: &Vec<Board>) {
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         Material::new()
     }, |mut t| {
         #[allow(unused_variables)]
@@ -50,12 +50,12 @@ fn bench_100_material_eval(b: &mut Bencher,  boards: &Vec<Board>) {
             let entry: &mut MaterialEntry = black_box(t.probe(board));
             score += black_box(entry.value) as i64;
         }
-    })
+    }, BatchSize::PerIteration)
 }
 
 
 fn bench_100_eval(b: &mut Bencher,  boards: &Vec<Board>) {
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         let tp: PawnTable = black_box(PawnTable::new());
         let tm: Material = black_box(Material::new());
         (tp, tm)
@@ -65,7 +65,7 @@ fn bench_100_eval(b: &mut Bencher,  boards: &Vec<Board>) {
         for board in boards.iter() {
             score += black_box(Evaluation::evaluate(&board, &mut tp, &mut tm)) as i64;
         }
-    })
+    }, BatchSize::PerIteration)
 }
 
 fn bench_engine_evaluations(c: &mut Criterion) {

--- a/pleco_engine/benches/eval_benches.rs
+++ b/pleco_engine/benches/eval_benches.rs
@@ -85,8 +85,8 @@ fn bench_engine_evaluations(c: &mut Criterion) {
 
 criterion_group!(name = eval_benches;
      config = Criterion::default()
-        .sample_size(60)
-        .warm_up_time(Duration::from_millis(5));
+        .sample_size(100)
+        .warm_up_time(Duration::from_millis(20));
     targets = bench_engine_evaluations
 );
 

--- a/pleco_engine/benches/multimove_benches.rs
+++ b/pleco_engine/benches/multimove_benches.rs
@@ -61,8 +61,8 @@ fn bench_engine_evaluations(c: &mut Criterion) {
 
 criterion_group!(name = search_multimove;
      config = Criterion::default()
-        .sample_size(26)
-        .warm_up_time(Duration::from_millis(100));
+        .sample_size(35)
+        .warm_up_time(Duration::from_millis(150));
     targets = bench_engine_evaluations
 );
 

--- a/pleco_engine/benches/multimove_benches.rs
+++ b/pleco_engine/benches/multimove_benches.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use criterion::{Criterion,black_box,Bencher};
+use criterion::{Criterion,black_box,Bencher,BatchSize};
 
 use pleco::{Board};
 
@@ -17,7 +17,7 @@ fn search_kiwipete_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
     let mut searcher = PlecoSearcher::init(false);
     let limit = pre_limit.create();
     let board_kwi: Board = Board::from_fen(KIWIPETE).unwrap();
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         threadpool().clear_all();
         searcher.clear_tt();
         board_kwi.shallow_clone()
@@ -27,7 +27,7 @@ fn search_kiwipete_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
         let mov = black_box(threadpool().search(&board, &limit));
         board.apply_move(mov);
         black_box(threadpool().search(&board, &limit));
-    })
+    }, BatchSize::PerIteration)
 }
 
 fn search_startpos_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
@@ -35,7 +35,7 @@ fn search_startpos_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
     pre_limit.depth = Some(D::depth());
     let mut searcher = PlecoSearcher::init(false);
     let limit = pre_limit.create();
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         threadpool().clear_all();
         searcher.clear_tt();
         Board::start_pos()
@@ -45,18 +45,18 @@ fn search_startpos_3moves_engine<D: DepthLimit>(b: &mut Bencher) {
         let mov = black_box(threadpool().search(&board, &limit));
         board.apply_move(mov);
         black_box(threadpool().search(&board, &limit));
-    })
+    }, BatchSize::PerIteration)
 }
 
 fn bench_engine_evaluations(c: &mut Criterion) {
-    c.bench_function("Search MuliMove Depth 5", search_startpos_3moves_engine::<Depth5>);
-    c.bench_function("Search MuliMove Depth 6", search_startpos_3moves_engine::<Depth6>);
-    c.bench_function("Search MuliMove Depth 7", search_startpos_3moves_engine::<Depth7>);
-    c.bench_function("Search MuliMove Depth 8", search_startpos_3moves_engine::<Depth8>);
-    c.bench_function("Search KiwiPete MuliMove Depth 5", search_kiwipete_3moves_engine::<Depth5>);
-    c.bench_function("Search KiwiPete MuliMove Depth 6", search_kiwipete_3moves_engine::<Depth6>);
-    c.bench_function("Search KiwiPete MuliMove Depth 7", search_kiwipete_3moves_engine::<Depth7>);
-    c.bench_function("Search KiwiPete MuliMove Depth 8", search_kiwipete_3moves_engine::<Depth8>);
+    c.bench_function("Search MultiMove Depth 5", search_startpos_3moves_engine::<Depth5>);
+    c.bench_function("Search MultiMove Depth 6", search_startpos_3moves_engine::<Depth6>);
+    c.bench_function("Search MultiMove Depth 7", search_startpos_3moves_engine::<Depth7>);
+    c.bench_function("Search MultiMove Depth 8", search_startpos_3moves_engine::<Depth8>);
+    c.bench_function("Search KiwiPete MultiMove Depth 5", search_kiwipete_3moves_engine::<Depth5>);
+    c.bench_function("Search KiwiPete MultiMove Depth 6", search_kiwipete_3moves_engine::<Depth6>);
+    c.bench_function("Search KiwiPete MultiMove Depth 7", search_kiwipete_3moves_engine::<Depth7>);
+    c.bench_function("Search KiwiPete MultiMove Depth 8", search_kiwipete_3moves_engine::<Depth8>);
 }
 
 criterion_group!(name = search_multimove;

--- a/pleco_engine/benches/startpos_benches.rs
+++ b/pleco_engine/benches/startpos_benches.rs
@@ -34,8 +34,8 @@ fn bench_engine_evaluations(c: &mut Criterion) {
 
 criterion_group!(name = search_singular;
      config = Criterion::default()
-        .sample_size(25)
-        .warm_up_time(Duration::from_millis(100));
+        .sample_size(35)
+        .warm_up_time(Duration::from_millis(150));
     targets = bench_engine_evaluations
 );
 

--- a/pleco_engine/benches/startpos_benches.rs
+++ b/pleco_engine/benches/startpos_benches.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use criterion::{Criterion,black_box,Bencher};
+use criterion::{Criterion,black_box,Bencher,BatchSize};
 
 use pleco::{Board};
 
@@ -15,13 +15,13 @@ fn search_singular_engine<D: DepthLimit>(b: &mut Bencher) {
     pre_limit.depth = Some(D::depth());
     let mut searcher = PlecoSearcher::init(false);
     let limit = pre_limit.create();
-    b.iter_with_setup(|| {
+    b.iter_batched(|| {
         threadpool().clear_all();
         searcher.clear_tt();
         Board::start_pos()
     }, |board| {
         black_box(threadpool().search(&board, &limit));
-    })
+    }, BatchSize::PerIteration)
 }
 
 fn bench_engine_evaluations(c: &mut Criterion) {

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -8,13 +8,6 @@
 //!
 
 #![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", allow(inline_always))]
-#![cfg_attr(feature="clippy", allow(unreadable_literal))]
-#![cfg_attr(feature="clippy", allow(large_digit_groups))]
-#![cfg_attr(feature="clippy", allow(cast_lossless))]
-#![cfg_attr(feature="clippy", allow(doc_markdown))]
-#![cfg_attr(feature="clippy", allow(inconsistent_digit_grouping))]
 
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![cfg_attr(test, allow(dead_code))]
@@ -28,6 +21,8 @@
 #![feature(trusted_len)]
 #![feature(const_fn)]
 #![feature(box_into_raw_non_null)]
+#![feature(alloc_layout_extra)]
+#![feature(thread_spawn_unchecked)]
 
 //#![crate_type = "staticlib"]
 
@@ -35,7 +30,6 @@ extern crate num_cpus;
 extern crate rand;
 extern crate pleco;
 extern crate chrono;
-extern crate crossbeam_utils;
 extern crate prefetch;
 
 pub mod threadpool;

--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -6,9 +6,6 @@
 //! If you are interested in using the direct chess library functions (The Boards, move generation, etc), please
 //! checkout the core library, `pleco`, available on [on crates.io](https://crates.io/crates/pleco).
 //!
-
-#![cfg_attr(feature="clippy", feature(plugin))]
-
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![cfg_attr(test, allow(dead_code))]
 

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -8,8 +8,6 @@ use std::ptr::NonNull;
 use std::{ptr,mem};
 use std::cell::UnsafeCell;
 
-use crossbeam_utils::thread as crossbeam;
-
 use pleco::MoveList;
 use pleco::tools::pleco_arc::Arc;
 use pleco::board::*;
@@ -47,8 +45,7 @@ pub fn init_threadpool() {
                 .name("Starter".to_string())
                 .stack_size(THREAD_STACK_SIZE);
 
-            let handle = crossbeam::builder_spawn_unchecked(
-                builder,
+            let handle = builder.spawn_unchecked(
                 move || {
                     let pool: *mut ThreadPool = mem::transmute(&mut THREADPOOL);
                     ptr::write(pool, ThreadPool::new());
@@ -125,7 +122,7 @@ impl ThreadPool {
                  .name(self.size().to_string())
                  .stack_size(THREAD_STACK_SIZE);
 
-             let handle = crossbeam::builder_spawn_unchecked(builder,
+             let handle = builder.spawn_unchecked(
                 move || {
                     let thread = &mut **thread_ptr.ptr.get();
                     thread.cond.lock();


### PR DESCRIPTION
General Changes
- Update Dependencies (`lazy_static`, `rand`, `num_cpus`, `rayon`)
- Remove `clippy` cfgs.
- Remove stabilized features from crate roots.

`pleco` Changes
- Updated benchmarks to initialize `lazy_static` statics before benchmarking.

`pleco_engine` Changes
- Update benchmarks to use `criterion::iter_batched`.
- Remove dependency on `crossbeam`, as unsafely scoped threads are available in the standard library.
