### PR TITLE
Pleco Compilation on Stable, Optimizations, Doc Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rust:
 
 
 cache:
-
   - cargo
   - apt
 #  cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ sudo: required
 env:
   global:
     - RUST_BACKTRACE=FULL
-    - RUSTFLAGS="-Ctarget-cpu=native -Zmutable-noalias"
+    - RUSTFLAGS="-Ctarget-cpu=native"
     - RUST_MIN_STACK=8000000
 #    - RUST_TEST_THREADS=1
 
@@ -46,7 +46,7 @@ script:
   - cargo +stable bench --package pleco
   - echo " ------ TESTING NIGHTLY BRANCH ------- "
   - cargo test --verbose
-  - cargo bench
+  - cargo bench -- -Zmutable-noalias
 #  - cd pleco/ && cargo bench
 #  - cd ../pleco_engine/ && cargo bench --bench eval_benches
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ env:
 #      - kalakris-cmake
 
 
+before_script:
+  - rustup install stable-x86_64-unknown-linux-gnu
+
 os:
   - linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ os:
 
 script:
   - cargo build --verbose
+  - echo " ------ TESTING STABLE BRANCH ------- "
+  - cargo +stable test --package pleco
+  - cargo +stable bench --package pleco
+  - echo " ------ TESTING NIGHTLY BRANCH ------- "
   - cargo test --verbose
   - cargo bench
 #  - cd pleco/ && cargo bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - cargo +stable bench --package pleco
   - echo " ------ TESTING NIGHTLY BRANCH ------- "
   - cargo test --verbose
-  - cargo bench -- -Z mutable-noalias
+  - cargo bench 
 #  - cd pleco/ && cargo bench
 #  - cd ../pleco_engine/ && cargo bench --bench eval_benches
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - cargo +stable bench --package pleco
   - echo " ------ TESTING NIGHTLY BRANCH ------- "
   - cargo test --verbose
-  - cargo bench 
+  - cargo bench
 #  - cd pleco/ && cargo bench
 #  - cd ../pleco_engine/ && cargo bench --bench eval_benches
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - cargo +stable bench --package pleco
   - echo " ------ TESTING NIGHTLY BRANCH ------- "
   - cargo test --verbose
-  - cargo bench -- -Zmutable-noalias
+  - cargo bench -- -Z mutable-noalias
 #  - cd pleco/ && cargo bench
 #  - cd ../pleco_engine/ && cargo bench --bench eval_benches
 

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -60,7 +60,6 @@ bitflags = "1.0.4"
 rand = "0.6.5"
 rayon = "1.0.3"
 num_cpus = "1.10.0"
-#prefetch = "0.2.0"
 mucow = "0.1.0"
 lazy_static = "1.3.0"
 
@@ -70,9 +69,6 @@ nightly = []
 
 [dev-dependencies]
 criterion = { version = '0.2.10', default-features = false}
-
-#[build-dependencies]
-#itertools = {version = "0.8"}
 
 [[bench]]
 name = "bench_main"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 categories = ["games","game-engines"]
 repository = "https://github.com/sfleischman105/Pleco"
 autobenches = false
-
+#build = "build.rs"
 
 include = [
     "src/*",
@@ -27,7 +27,6 @@ coveralls = { repository = "sfleischman105/Pleco", branch = "master", service = 
 
 [lib]
 name = "pleco"
-#bench = true
 path = "src/lib.rs"
 doctest = true
 
@@ -61,15 +60,20 @@ bitflags = "1.0.4"
 rand = "0.6.5"
 rayon = "1.0.3"
 num_cpus = "1.10.0"
-prefetch = "0.2.0"
+#prefetch = "0.2.0"
 mucow = "0.1.0"
 lazy_static = "1.3.0"
 
 [features]
 default = []
+nightly = ["criterion/real_blackbox"]
 
 [dev-dependencies]
-criterion = { version = '0.2.10', default-features = false, features=['real_blackbox'] }
+#criterion = { version = '0.2.10', default-features = false, features=['real_blackbox'] }
+criterion = { version = '0.2.10', default-features = false }
+
+#[build-dependencies]
+#itertools = {version = "0.8"}
 
 [[bench]]
 name = "bench_main"

--- a/pleco/Cargo.toml
+++ b/pleco/Cargo.toml
@@ -66,11 +66,10 @@ lazy_static = "1.3.0"
 
 [features]
 default = []
-nightly = ["criterion/real_blackbox"]
+nightly = []
 
 [dev-dependencies]
-#criterion = { version = '0.2.10', default-features = false, features=['real_blackbox'] }
-criterion = { version = '0.2.10', default-features = false }
+criterion = { version = '0.2.10', default-features = false}
 
 #[build-dependencies]
 #itertools = {version = "0.8"}

--- a/pleco/README.md
+++ b/pleco/README.md
@@ -35,7 +35,7 @@ Use
 -------
 
 To use Pleco inside your own Rust projects, [Pleco.rs is available as a library on crates.io](https://crates.io/crates/pleco). 
-`nightly` rust is required to use. 
+Pleco runs on all three distributions (`nightly`, `beta`, `stable`) of rust.
 
 ### Basic Usage
 

--- a/pleco/README.md
+++ b/pleco/README.md
@@ -95,6 +95,17 @@ board.undo_move();
 assert_eq!(board.moves_played(),0);
 ```
 
+#### Features
+
+If on nightly rust, the feature `"nightly"` is available. This enables some nightly
+optimizations and speed improvements.
+
+Usage is as easy as updating your `cargo.toml` to include:
+
+```
+[dependencies]
+pleco = {version = "*", features = ["nightly"]}
+```
   
 Contributing
 -------

--- a/pleco/benches/perft_benches.rs
+++ b/pleco/benches/perft_benches.rs
@@ -38,8 +38,8 @@ fn perft_all(c: &mut Criterion) {
 
 criterion_group!(name = perft_benches;
      config = Criterion::default()
-        .sample_size(8)
-        .warm_up_time(Duration::from_millis(10));
+        .sample_size(12)
+        .warm_up_time(Duration::from_millis(20));
     targets = perft_all
 );
 

--- a/pleco/src/board/board_state.rs
+++ b/pleco/src/board/board_state.rs
@@ -20,7 +20,6 @@ use core::bitboard::BitBoard;
 use core::masks::*;
 use core::score::{Value,Score};
 
-//use std::sync::Arc;
 use tools::pleco_arc::Arc;
 use helper::prelude::*;
 
@@ -156,7 +155,7 @@ impl BoardState {
     ///
     /// Specifically, sets Blockers, Pinners, and Check Squares for each piece.
     ///
-    /// The `checkers_bb` must beset before this methof can be used.
+    /// The `checkers_bb` must beset before this method can be used.
     pub(crate) fn set_check_info(&mut self, board: &Board) {
         let mut white_pinners: BitBoard = BitBoard(0);
 

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -756,11 +756,10 @@ impl Board {
         }
         self.state = next_arc_state.shareable();
 
-        if cfg!(debug_assertions) {
-            self.is_okay().unwrap();
-        } else {
-            assert!(self.is_ok_quick());
-        }
+        #[cfg(debug_assertions)]
+        self.is_okay().unwrap();
+        #[cfg(not(debug_assertions))]
+        assert!(self.is_ok_quick());
     }
 
     /// Applies a UCI move to the board. If the move is a valid string representing a UCI move, then
@@ -855,11 +854,10 @@ impl Board {
         self.half_moves -= 1;
         self.depth -= 1;
 
-        if cfg!(debug_assertions) {
-            self.is_okay().unwrap();
-        } else {
-            assert!(self.is_ok_quick());
-        }
+        #[cfg(debug_assertions)]
+        self.is_okay().unwrap();
+        #[cfg(not(debug_assertions))]
+        assert!(self.is_ok_quick());
     }
 
     /// Apply a "Null Move" to the board, essentially swapping the current turn of
@@ -920,11 +918,10 @@ impl Board {
         }
         self.state = next_arc_state.shareable();
 
-        if cfg!(debug_assertions) {
-            self.is_okay().unwrap();
-        } else {
-            assert!(self.is_ok_quick());
-        }
+        #[cfg(debug_assertions)]
+        self.is_okay().unwrap();
+        #[cfg(not(debug_assertions))]
+        assert!(self.is_ok_quick());
     }
 
     /// Undo a "Null Move" to the Board, returning to the previous state.

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -1980,6 +1980,12 @@ impl Board {
 
     /// `see_ge` stands for Static Exchange Evaluation, Greater or Equal. This teats if the
     /// Static Exchange Evaluation of a move is greater than or equal to a value.
+    ///
+    /// This is a recursive algorithm that works by checking the destination square of
+    /// the given move, and attempting to repeatedly capture that spot for both players.
+    ///
+    /// If the move is invalid for the current board, `false` will be returned regardless
+    /// of the threshold.
     pub fn see_ge(&self, mov: BitMove, threshold: i32) -> bool {
         if mov.move_type() != MoveType::Normal {
             return 0 >= threshold;

--- a/pleco/src/board/piece_locations.rs
+++ b/pleco/src/board/piece_locations.rs
@@ -46,7 +46,7 @@ impl PieceLocations {
     ///
     /// # Panics
     ///
-    /// Panics if Square is of index higher than 63.
+    /// Panics if Square is of index higher than 63 or the piece is `PieceType::{None || All}`
     #[inline]
     pub fn place(&mut self, square: SQ, player: Player, piece: PieceType) {
         debug_assert!(square.is_okay());

--- a/pleco/src/core/bitboard.rs
+++ b/pleco/src/core/bitboard.rs
@@ -163,6 +163,13 @@ impl BitBoard {
 
     /// Returns the index (as a square) of the least significant bit and removes
     /// that bit from the `BitBoard`.
+    ///
+    /// # Safety
+    ///
+    /// Panics if the `BitBoard` is empty. See [`BitBoard::pop_some_lsb`] for a
+    /// non-panicking version of the method.
+    ///
+    /// [`BitBoard::pop_some_lsb`]: struct.BitBoard.html#method.pop_some_lsb
     #[inline(always)]
     pub fn pop_lsb(&mut self) -> SQ {
         let sq = self.bit_scan_forward();
@@ -170,7 +177,8 @@ impl BitBoard {
         sq
     }
 
-    /// Returns the least significant bit of a `BitBoard`, if it has any.
+    /// Returns the least significant bit of a `BitBoard`, if it has any. If there is a bit to
+    /// return, it removes that bit from itself.
     #[inline(always)]
     pub fn pop_some_lsb(&mut self) -> Option<SQ> {
         if self.is_empty() {
@@ -182,6 +190,13 @@ impl BitBoard {
 
     /// Returns the index (as a square) and bit of the least significant bit and removes
     /// that bit from the `BitBoard`.
+    ///
+    /// # Safety
+    ///
+    /// Panics if the `BitBoard` is empty. See [`BitBoard::pop_some_lsb_and_bit`] for a
+    /// non-panicking version of the method.
+    ///
+    /// [`BitBoard::pop_some_lsb_and_bit`]: struct.BitBoard.html#method.pop_some_lsb_and_bit
     #[inline(always)]
     pub fn pop_lsb_and_bit(&mut self) -> (SQ, BitBoard) {
         let sq: SQ = self.bit_scan_forward();
@@ -189,6 +204,9 @@ impl BitBoard {
         (sq, sq.to_bb())
     }
 
+    /// Returns the index (as a square) and bit of the least significant bit and removes
+    /// that bit from the `BitBoard`. If there are no bits left (the board is empty), returns
+    /// `None`.
     #[inline(always)]
     pub fn pop_some_lsb_and_bit(&mut self) ->  Option<(SQ, BitBoard)> {
         if self.is_empty() {
@@ -202,7 +220,7 @@ impl BitBoard {
     ///
     /// # Safety
     ///
-    /// panics if the `BitBoard` is empty.
+    /// Panics if the `BitBoard` is empty.
     #[inline]
     pub fn frontmost_sq(self, player: Player) -> SQ {
         match player {

--- a/pleco/src/core/masks.rs
+++ b/pleco/src/core/masks.rs
@@ -243,6 +243,17 @@ pub static SQ_DISPLAY_ORDER: [u8; SQ_CNT] = [56, 57, 58, 59, 60, 61, 62, 63,
     8,  9,  10, 11, 12, 13, 14, 15,
     0,  1,   2,  3,  4,  5,  6,  7];
 
+/// Array mapping a square index to a string representation.
+///
+/// # Examples
+///
+/// ```
+/// use pleco::core::masks::SQ_DISPLAY;
+///
+/// assert_eq!(SQ_DISPLAY[0], "a1");
+/// assert_eq!(SQ_DISPLAY[1], "b1");
+/// assert_eq!(SQ_DISPLAY[8], "a2");
+/// ```
 pub static SQ_DISPLAY: [&str; SQ_CNT] = [
     "a1", "b1", "c1", "d1", "e1", "f1", "g1", "h1",
     "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2",
@@ -254,13 +265,34 @@ pub static SQ_DISPLAY: [&str; SQ_CNT] = [
     "a8", "b8", "c8", "d8", "e8", "f8", "g8", "h8"];
 
 /// Characters for each combination of player and piece.
+///
+/// White pieces are displayed as Uppercase letters, while black pieces are lowercase.
 pub static PIECE_DISPLAYS: [[char; PIECE_TYPE_CNT]; PLAYER_CNT] = [
     ['_', 'P', 'N', 'B', 'R', 'Q', 'K', '*'],
     ['_', 'p', 'n', 'b', 'r', 'q', 'k', '*'],
 ];
 
 /// Characters for each file, index from file A to file H.
+/// # Examples
+///
+/// ```
+/// use pleco::core::masks::FILE_DISPLAYS;
+///
+/// assert_eq!(FILE_DISPLAYS[0], "a");
+/// assert_eq!(FILE_DISPLAYS[1], "b");
+/// assert_eq!(FILE_DISPLAYS[7], "h");
+/// ```
 pub static FILE_DISPLAYS: [char; FILE_CNT] = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 
 /// Characters for each rank, index from rank 1 to rank 8.
+///
+/// # Examples
+///
+/// ```
+/// use pleco::core::masks::RANK_DISPLAYS;
+///
+/// assert_eq!(RANK_DISPLAYS[0], "1");
+/// assert_eq!(RANK_DISPLAYS[1], "2");
+/// assert_eq!(RANK_DISPLAYS[7], "8");
+/// ```
 pub static RANK_DISPLAYS: [char; FILE_CNT] = ['1', '2', '3', '4', '5', '6', '7', '8'];

--- a/pleco/src/core/masks.rs
+++ b/pleco/src/core/masks.rs
@@ -278,9 +278,9 @@ pub static PIECE_DISPLAYS: [[char; PIECE_TYPE_CNT]; PLAYER_CNT] = [
 /// ```
 /// use pleco::core::masks::FILE_DISPLAYS;
 ///
-/// assert_eq!(FILE_DISPLAYS[0], "a");
-/// assert_eq!(FILE_DISPLAYS[1], "b");
-/// assert_eq!(FILE_DISPLAYS[7], "h");
+/// assert_eq!(FILE_DISPLAYS[0], 'a');
+/// assert_eq!(FILE_DISPLAYS[1], 'b');
+/// assert_eq!(FILE_DISPLAYS[7], 'h');
 /// ```
 pub static FILE_DISPLAYS: [char; FILE_CNT] = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 
@@ -291,8 +291,8 @@ pub static FILE_DISPLAYS: [char; FILE_CNT] = ['a', 'b', 'c', 'd', 'e', 'f', 'g',
 /// ```
 /// use pleco::core::masks::RANK_DISPLAYS;
 ///
-/// assert_eq!(RANK_DISPLAYS[0], "1");
-/// assert_eq!(RANK_DISPLAYS[1], "2");
-/// assert_eq!(RANK_DISPLAYS[7], "8");
+/// assert_eq!(RANK_DISPLAYS[0], '1');
+/// assert_eq!(RANK_DISPLAYS[1], '2');
+/// assert_eq!(RANK_DISPLAYS[7], '8');
 /// ```
 pub static RANK_DISPLAYS: [char; FILE_CNT] = ['1', '2', '3', '4', '5', '6', '7', '8'];

--- a/pleco/src/core/mono_traits.rs
+++ b/pleco/src/core/mono_traits.rs
@@ -4,7 +4,7 @@
 //! This modules only use is to allow for compile-time mono-morphization of
 //! functions / methods, where each method created can be optimized further.
 //!
-//! We are awaiting the stabilization of `const fn` to remove these traits.
+//! We are awaiting the stabilization of `const fn` and constant generics to remove these traits.
 
 use super::{Player, PieceType, GenTypes};
 use super::sq::SQ;

--- a/pleco/src/core/move_list.rs
+++ b/pleco/src/core/move_list.rs
@@ -23,6 +23,7 @@ use std::iter::TrustedLen;
 
 use super::piece_move::{BitMove, ScoringMove};
 
+/// Trait to help generalize operations involving sctures containing a collection of `BitMove`s.
 pub trait MVPushable: Sized + IndexMut<usize> + Index<usize> + DerefMut {
 
     /// Adds a `BitMove` to the end of the list.
@@ -36,7 +37,7 @@ pub trait MVPushable: Sized + IndexMut<usize> + Index<usize> + DerefMut {
     ///
     /// # Safety
     ///
-    /// Undefined behavior if pushing to the list when `MoveList::len() = 256`.
+    /// Undefined behavior if pushing to the list when `MoveList::len() = MAX_MOVES`.
     unsafe fn unchecked_push_mv(&mut self, mv: BitMove);
 
     /// Set the length of the list.
@@ -47,14 +48,14 @@ pub trait MVPushable: Sized + IndexMut<usize> + Index<usize> + DerefMut {
     unsafe fn unchecked_set_len(&mut self, len: usize);
 
 
-    /// Return a pointer to the first (0-th index) element in the list
+    /// Return a pointer to the first (0-th index) element in the list.
     ///
     /// # Safety
     ///
     /// Unsafe due to allow modification of elements possibly not inside the length.
     unsafe fn list_ptr(&mut self) -> *mut Self::Output;
 
-    /// Return a pointer to the element next to the last element in the list
+    /// Return a pointer to the element next to the last element in the list.
     ///
     /// # Safety
     ///
@@ -62,12 +63,26 @@ pub trait MVPushable: Sized + IndexMut<usize> + Index<usize> + DerefMut {
     unsafe fn over_bounds_ptr(&mut self) -> *mut Self::Output;
 }
 
-const MAX_MOVES: usize = 256;
+/// The maximum number of moves a `MoveList` or `ScoringMoveList` may contain.
+///
+/// This value differs based on the `target_pointer_width` to align lists of moves into
+/// values equally dividable by the cache size.
+#[cfg(target_pointer_width = "128")]
+pub const MAX_MOVES: usize = 248;
+#[cfg(target_pointer_width = "64")]
+pub const MAX_MOVES: usize = 252;
+#[cfg(target_pointer_width = "32")]
+pub const MAX_MOVES: usize = 254;
+#[cfg(any(
+    target_pointer_width = "16",
+    target_pointer_width = "8",
+))]
+pub const MAX_MOVES: usize = 255;
 
 /// This is the list of possible moves for a current position. Think of it alike a faster
 /// version of `Vec<BitMove>`, as all the data is stored in the Stack rather than the Heap.
 pub struct MoveList {
-    inner: [BitMove; 256],
+    inner: [BitMove; MAX_MOVES],
     len: usize,
 }
 
@@ -75,7 +90,7 @@ impl Default for MoveList {
     #[inline]
     fn default() -> Self {
         MoveList {
-            inner: [BitMove::null(); 256],
+            inner: [BitMove::null(); MAX_MOVES],
             len: 0,
         }
     }
@@ -375,7 +390,7 @@ unsafe impl TrustedLen for MoveIntoIter {}
 
 /// This is similar to a `MoveList`, but also keeps the scores for each move as well.
 pub struct ScoringMoveList {
-    inner: [ScoringMove; 256],
+    inner: [ScoringMove; MAX_MOVES],
     len: usize,
 }
 
@@ -383,7 +398,7 @@ impl Default for ScoringMoveList {
     #[inline]
     fn default() -> Self {
         ScoringMoveList {
-            inner: [ScoringMove::default(); 256],
+            inner: [ScoringMove::default(); MAX_MOVES],
             len: 0,
         }
     }

--- a/pleco/src/core/move_list.rs
+++ b/pleco/src/core/move_list.rs
@@ -17,7 +17,10 @@
 
 use std::slice;
 use std::ops::{Deref,DerefMut,Index,IndexMut};
-use std::iter::{Iterator,IntoIterator,FusedIterator,TrustedLen,ExactSizeIterator,FromIterator};
+use std::iter::{Iterator,IntoIterator,FusedIterator,ExactSizeIterator,FromIterator};
+#[cfg(feature = "nightly")]
+use std::iter::TrustedLen;
+
 use super::piece_move::{BitMove, ScoringMove};
 
 pub trait MVPushable: Sized + IndexMut<usize> + Index<usize> + DerefMut {
@@ -307,6 +310,7 @@ impl<'a> ExactSizeIterator for MoveIter<'a> {}
 
 impl<'a> FusedIterator for MoveIter<'a> {}
 
+#[cfg(feature = "nightly")]
 unsafe impl<'a> TrustedLen for MoveIter<'a> {}
 
 // Iterator for the `MoveList`.
@@ -365,6 +369,7 @@ impl ExactSizeIterator for MoveIntoIter {}
 
 impl FusedIterator for MoveIntoIter {}
 
+#[cfg(feature = "nightly")]
 unsafe impl TrustedLen for MoveIntoIter {}
 
 
@@ -588,6 +593,7 @@ impl<'a> ExactSizeIterator for ScoreMoveIter<'a> {}
 
 impl<'a> FusedIterator for ScoreMoveIter<'a> {}
 
+#[cfg(feature = "nightly")]
 unsafe impl<'a> TrustedLen for ScoreMoveIter<'a> {}
 
 // Iterator for the `ScoringMoveList`.
@@ -646,4 +652,5 @@ impl ExactSizeIterator for ScoreMoveIntoIter {}
 
 impl FusedIterator for ScoreMoveIntoIter {}
 
+#[cfg(feature = "nightly")]
 unsafe impl TrustedLen for ScoreMoveIntoIter {}

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -466,7 +466,9 @@ impl BitMove {
     }
 }
 
-/// A move that stores a score as well
+/// Structure containing both a score (represented as a i16) and a `BitMove`.
+///
+/// This is useful for tracking a list of moves alongside each of their scores.
 #[derive(Eq, Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ScoringMove {
@@ -485,6 +487,7 @@ impl Default for ScoringMove {
 }
 
 impl ScoringMove {
+    /// Creates a new `ScoringMove` with a default score of 0.
     #[inline(always)]
     pub fn new(m: BitMove) -> Self {
         ScoringMove {
@@ -493,6 +496,7 @@ impl ScoringMove {
         }
     }
 
+    /// Creates a new `ScoringMove`.
     #[inline(always)]
     pub fn new_score(m: BitMove, score: i16) -> Self {
         ScoringMove {
@@ -501,6 +505,7 @@ impl ScoringMove {
         }
     }
 
+    /// Returns a `ScoringMove` containing a `BitMove::null()` and a user-defined score.
     #[inline(always)]
     pub fn blank(score: i16) -> Self {
         ScoringMove {
@@ -509,28 +514,33 @@ impl ScoringMove {
         }
     }
 
+    /// Returns the move.
     #[inline(always)]
     pub fn bitmove(&self) -> BitMove {
         self.bit_move
     }
 
+    /// Returns the score.
     #[inline(always)]
     pub fn score(&self) -> i16 {
         self.score
     }
 
+    /// Negates the current score.
     #[inline(always)]
     pub fn negate(mut self) -> Self {
         self.score = self.score.wrapping_neg();
         self
     }
 
+    /// Swaps the current move with another move.
     #[inline(always)]
     pub fn swap_move(mut self, mov: BitMove) -> Self {
         self.bit_move = mov;
         self
     }
 
+    /// Returns a `ScoringMove` containing a `BitMove::null()` and a score of zero.
     #[inline(always)]
     pub const fn null() -> Self {
         ScoringMove {

--- a/pleco/src/core/score.rs
+++ b/pleco/src/core/score.rs
@@ -1,12 +1,14 @@
 //! Primitives for determining the value / score of a specific location.
 //!
-//! A `Value` stores a single `i16` to represent a score. `Score` stores two `i16`s inside of it,
+//! A `Value` stores a single `i32` to represent a score. `Score` stores two `i32`s inside of it,
 //! the first to determine the mid-game score, and the second to determine the end-game score.
 
 use std::ops::*;
 use std::fmt;
 
-/// Type for `i16` to determine the `Value` of an evaluation.
+// TODO: Why is Value an i32 now? Need some notes on why that changed.
+
+/// Type for `i32` to determine the `Value` of an evaluation.
 pub type Value = i32;
 
 

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -1,22 +1,33 @@
-//! A Rust re-write of the basic building blocks of the [Stockfish](https://stockfishchess.org/)
-//! chess engine.
+//! A blazingly fast chess library.
 //!
 //! This package is separated into two parts. Firstly, the board representation & associated functions
 //! (the current crate, `pleco`), and secondly, the AI implementations using these chess foundations,
 //! [pleco_engine](https://crates.io/crates/pleco_engine).
 //!
-//! This crate requires *nightly* Rust to use.
+//! The general formatting and structure of the library take heavy influence from the basic building
+//! blocks of the [Stockfish](https://stockfishchess.org/) chess engine.
 //!
 //! # Usage
 //!
 //! This crate is [on crates.io](https://crates.io/crates/pleco) and can be
 //! used by adding `pleco` to the dependencies in your project's `Cargo.toml`.
 //!
+//! # Platforms
+//!
+//! `pleco` is currently tested and created for use with the `x86_64` instruction set in mind.
+//! Currently, there are no guarantees of correct behavior if compiled for a different
+//! instruction set.
+//!
+//! # Nightly Features
+//!
+//! If on nightly rust, the feature `nightly` is available. This enables some nightly
+//! optimizations and speed improvements.
+//!
 //! # Safety
 //!
-//! While generally a safe library, pleco was built with a focus of speed in mind. Usage of methods must be followed
-//! carefully, as there are many possible ways to `panic` unexpectedly. Methods with the ability to panic will be
-//! documented as such.
+//! While generally a safe library, pleco was built with a focus of speed in mind. Usage of methods
+//! must be followed carefully, as there are many possible ways to `panic` unexpectedly. Methods
+//! with the ability to panic will be documented as such.
 //!
 //! # Examples
 //!
@@ -60,12 +71,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
 //#![crate_type = "rlib"]
-
-// Unneeded I think
-//#![feature(test)]
-//#![feature(integer_atomics)]
-//#![feature(const_fn)]
-//#![feature(stdsimd)]
 
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(feature = "nightly", feature(const_slice_len))]

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -67,9 +67,9 @@
 //#![feature(const_fn)]
 //#![feature(stdsimd)]
 
-// Need these for nightly
-#![feature(const_slice_len)] // General Usage
-#![feature(trusted_len)]     // used in MoveList
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(const_slice_len))]
+#![cfg_attr(feature = "nightly", feature(trusted_len))]
 
 #![allow(dead_code)]
 
@@ -80,8 +80,6 @@ extern crate lazy_static;
 extern crate num_cpus;
 extern crate rand;
 extern crate rayon;
-// This requires nightly, probably should find a better way to prefetch.
-extern crate prefetch;
 extern crate mucow;
 
 pub mod core;

--- a/pleco/src/lib.rs
+++ b/pleco/src/lib.rs
@@ -61,14 +61,16 @@
 
 //#![crate_type = "rlib"]
 
-#![feature(trusted_len)]
-#![feature(test)]
-#![feature(integer_atomics)]
-#![feature(allocator_api)]
-#![feature(const_fn)]
-#![feature(stdsimd)]
-#![feature(const_slice_len)]
-#![feature(alloc_layout_extra)]
+// Unneeded I think
+//#![feature(test)]
+//#![feature(integer_atomics)]
+//#![feature(const_fn)]
+//#![feature(stdsimd)]
+
+// Need these for nightly
+#![feature(const_slice_len)] // General Usage
+#![feature(trusted_len)]     // used in MoveList
+
 #![allow(dead_code)]
 
 #[macro_use]
@@ -78,6 +80,7 @@ extern crate lazy_static;
 extern crate num_cpus;
 extern crate rand;
 extern crate rayon;
+// This requires nightly, probably should find a better way to prefetch.
 extern crate prefetch;
 extern crate mucow;
 

--- a/pleco/src/tools/eval.rs
+++ b/pleco/src/tools/eval.rs
@@ -52,7 +52,7 @@ fn flatten(arr: [[i32; FILE_CNT]; RANK_CNT]) -> [i32; SQ_CNT] {
 ///
 /// let board = Board::start_pos();
 /// let score = Eval::eval_low(&board);
-/// println!("Score: {}");
+/// println!("Score: {}", score);
 /// ```
 pub struct Eval;
 

--- a/pleco/src/tools/eval.rs
+++ b/pleco/src/tools/eval.rs
@@ -43,7 +43,18 @@ fn flatten(arr: [[i32; FILE_CNT]; RANK_CNT]) -> [i32; SQ_CNT] {
     new_arr
 }
 
-pub struct Eval {}
+/// A simple evaluation structure. This is included as an example, and shouldn't
+/// neccessarily be used inside serious chess engines.
+///
+/// ```
+/// use pleco::tools::eval::Eval;
+/// use pleco::Board;
+///
+/// let board = Board::start_pos();
+/// let score = Eval::eval_low(&board);
+/// println!("Score: {}");
+/// ```
+pub struct Eval;
 
 trait EvalRuns {
     fn eval_castling<PlayerTrait>(&self) -> i32;

--- a/pleco/src/tools/mod.rs
+++ b/pleco/src/tools/mod.rs
@@ -22,6 +22,7 @@ pub trait Searcher {
             Self: Sized;
 }
 
+// https://doc.rust-lang.org/core/arch/x86_64/fn._mm_prefetch.html
 /// Allows an object to have it's entries pre-fetchable.
 pub trait PreFetchable {
     /// Pre-fetches a particular key. This means bringing it into the cache for faster access.

--- a/pleco/src/tools/prng.rs
+++ b/pleco/src/tools/prng.rs
@@ -1,6 +1,8 @@
 //! Contains the Pseudo-random number generator. Used for generating random `Board`s and
 //! `BitBoard`s.
 
+use std::mem::transmute;
+
 /// Object for generating pseudo-random numbers.
 pub struct PRNG {
     seed: u64,
@@ -33,8 +35,9 @@ impl PRNG {
 
     /// Returns a u64 with exactly one bit set in a random location.
     pub fn singular_bit(&mut self) -> u64 {
-        let num: u64 = 1;
-        num.wrapping_shl(self.rand().count_ones())
+        let arr: [u8; 8] = unsafe {transmute(self.rand() ^ self.rand())};
+        let byte: u8 = arr.iter().fold(0, |acc, &x| acc ^ x);
+        (1u64).wrapping_shl(((byte) >> 2) as u32)
     }
 
     /// Randomizes the current seed and returns a random value.
@@ -43,5 +46,43 @@ impl PRNG {
         self.seed ^= self.seed << 25;
         self.seed ^= self.seed >> 27;
         self.seed.wrapping_mul(2685_8216_5773_6338_717)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PRNG;
+
+    const ROUNDS: u32 = 4;
+    const MUTS: u32 = 32;
+
+    #[test]
+    fn check_bit_displacement() {
+        let mut seeder = PRNG::init(10300014);
+        let mut acc =  [0u32; 64];
+        for _ in 0..ROUNDS {
+            let mut prng = PRNG::init(seeder.rand());
+            for _ in 0..MUTS {
+                add_to_bit_counts(prng.singular_bit(), &mut acc);
+            }
+        }
+
+        let max = *acc.iter().max().unwrap();
+        for (_i, m) in acc.iter_mut().enumerate() {
+            *m *= 100;
+            *m /= max;
+            //println!("{} : {}",_i, m);
+        }
+
+        let _sum: u32 = acc.iter().sum();
+//        println!("avg: {}", _sum / 64);
+    }
+
+    fn add_to_bit_counts(mut num: u64, acc: &mut [u32; 64]) {
+        while num != 0 {
+            let i = num.trailing_zeros();
+            acc[i as usize] += 1;
+            num &= !((1u64) << i);
+        }
     }
 }

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -472,7 +472,7 @@ impl Drop for TranspositionTable {
     }
 }
 
-/// Returns the first entry of a cluster
+/// Returns the first entry of a cluster.
 #[inline]
 unsafe fn cluster_first_entry(cluster: *mut Cluster) -> *mut Entry {
     (*cluster).entry.get_unchecked_mut(0) as *mut Entry

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -39,10 +39,9 @@ use std::alloc::{Layout, handle_alloc_error, self};
 use std::cmp::min;
 use std::cell::UnsafeCell;
 
-use prefetch::prefetch::*;
-
 use super::PreFetchable;
 use core::piece_move::BitMove;
+use super::prefetch_write;
 
 // TODO: investigate potention for SIMD in key lookup
 // Currently, there is now way to do this right now in rust without it being extensive.
@@ -462,7 +461,7 @@ impl PreFetchable for TranspositionTable {
         let index: usize = ((self.num_clusters() - 1) as u64 & key) as usize;
         unsafe {
             let ptr = (*self.clusters.get()).as_ptr().offset(index as isize);
-            prefetch::<Write, High, Data, Cluster>(ptr);
+            prefetch_write(ptr);
         };
     }
 }

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -35,7 +35,7 @@
 
 use std::ptr::NonNull;
 use std::mem;
-use std::alloc::{Alloc, Layout, Global, handle_alloc_error};
+use std::alloc::{Layout, handle_alloc_error, self};
 use std::cmp::min;
 use std::cell::UnsafeCell;
 
@@ -283,7 +283,7 @@ impl TranspositionTable {
     ///
     /// This is function is unsafe to use if the TT is currently being accessed, Or any thread of
     /// structure contains a current reference to a `TTEntry`. Otherwise, using this function will
-    /// absolutely lead to Segmentation Fault.
+    /// absolutely lead to a Segmentation Fault.
     pub unsafe fn resize_round_up(&self, size: usize) {
         self.resize(size.next_power_of_two());
     }
@@ -323,7 +323,7 @@ impl TranspositionTable {
     ///
     /// This is function is unsafe to use if the TT is currently being accessed, Or any thread of
     /// structure contains a current reference to a `TTEntry`. Otherwise, using this function will
-    /// absolutely lead to Segmentation Fault.
+    /// absolutely lead to a Segmentation Fault.
     pub unsafe fn clear(&self) {
         let size = self.cap.get();
         self.resize(*size);
@@ -423,8 +423,10 @@ impl TranspositionTable {
 
     /// De-allocates the current heap.
     unsafe fn de_alloc(&self) {
-        let ptr: NonNull<u8> = mem::transmute(*self.clusters.get());
-        Global.dealloc(ptr, Layout::array::<Cluster>(*self.cap.get()).unwrap());
+        let layout = Layout::from_size_align(*self.cap.get(), 2).unwrap();
+        let ptr: *mut u8 = mem::transmute(*self.clusters.get());
+//        alloc::dealloc(ptr, Layout::array::<Cluster>(*self.cap.get()).unwrap());
+        alloc::dealloc(ptr, layout);
     }
 
     /// Returns the % of the hash table that is full.
@@ -481,12 +483,13 @@ unsafe fn cluster_first_entry(cluster: *mut Cluster) -> *mut Entry {
 #[inline]
 fn alloc_room(size: usize) -> NonNull<Cluster> {
     unsafe {
-        let layout = Layout::array::<Cluster>(size).unwrap();
-        let ptr = Global.alloc_zeroed(layout);
-
-        let new_ptr = match ptr {
-            Ok(ptr) => ptr.cast(),
-            Err(_err) => handle_alloc_error(layout),
+        let size = size * mem::size_of::<Cluster>();
+        let layout = Layout::from_size_align(size, 2).unwrap();
+        //let layout = Layout::array::<Cluster>(size).unwrap();
+        let ptr: *mut u8 = alloc::alloc_zeroed(layout);
+        let new_ptr: NonNull<Cluster> = match NonNull::new(ptr) {
+            Some(ptr) => ptr.cast(),
+            _ => handle_alloc_error(layout),
         };
         new_ptr
     }
@@ -510,6 +513,16 @@ mod tests {
     const HALF_GIG: usize = 2 << 24;
     // around 30 MB
     const THIRTY_MB: usize = 2 << 20;
+
+//    #[test]
+//    fn cluster_alloc_size_align() {
+//        for i in 0..10 {
+//            let size = 1 << i;
+//            let layout = Layout::array::<Cluster>(1 << i).unwrap();
+//            assert_eq!(layout.align(), 2);
+//            assert_eq!(layout.size(),  mem::size_of::<Cluster>() * size);
+//        }
+//    }
 
     #[test]
     fn tt_alloc_realloc() {

--- a/pleco/tests/test.rs
+++ b/pleco/tests/test.rs
@@ -1,7 +1,5 @@
-#![feature(test)]
 
 extern crate pleco;
-extern crate test;
 
 mod board_build;
 mod move_generating;

--- a/pleco_engine/Cargo.toml
+++ b/pleco_engine/Cargo.toml
@@ -57,7 +57,7 @@ path = "src/lib.rs"
 doctest = true
 
 [dependencies]
-pleco = { path = "../pleco", version = "0.4.4" }
+pleco = { path = "../pleco", version = "*", features =["nightly"]}
 chrono = "0.4.6"
 rand = "0.6.5"
 num_cpus = "1.8.0"

--- a/pleco_engine/src/root_moves/mod.rs
+++ b/pleco_engine/src/root_moves/mod.rs
@@ -8,7 +8,8 @@ use std::cmp::Ordering as CmpOrder;
 use pleco::core::score::*;
 use pleco::BitMove;
 
-const MAX_MOVES: usize = 256;
+// 250 as this fits into 64 byte cache lines easily.
+const MAX_MOVES: usize = 250;
 
 /// Keeps track of information of a move for the position to be searched.
 #[derive(Copy, Clone,Eq)]

--- a/pleco_engine/src/tables/material.rs
+++ b/pleco_engine/src/tables/material.rs
@@ -1,12 +1,10 @@
 //! Table to map from position -> material value;
 
-use prefetch::prefetch::*;
-
 use pleco::{Player, Board, PieceType};
 use pleco::core::masks::{PLAYER_CNT,PIECE_TYPE_CNT};
 use pleco::core::score::*;
 use pleco::core::mono_traits::*;
-use pleco::tools::PreFetchable;
+use pleco::tools::{PreFetchable, prefetch_write};
 
 use super::{TableBase,TableBaseConst};
 
@@ -79,7 +77,7 @@ impl PreFetchable for Material {
     fn prefetch(&self, key: u64) {
         unsafe {
             let ptr = self.table.get_ptr(key);
-            prefetch::<Write, High, Data, MaterialEntry>(ptr);
+            prefetch_write(ptr);
         }
     }
 }

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -6,8 +6,6 @@
 
 use std::mem::transmute;
 
-use prefetch::prefetch::*;
-
 use pleco::{Player, File, SQ, BitBoard, Board, PieceType, Rank, Piece};
 use pleco::core::masks::{PLAYER_CNT,RANK_CNT};
 use pleco::core::score::*;
@@ -15,7 +13,7 @@ use pleco::core::mono_traits::*;
 use pleco::board::castle_rights::Castling;
 use pleco::core::CastleType;
 use pleco::helper::prelude::*;
-use pleco::tools::PreFetchable;
+use pleco::tools::{PreFetchable,prefetch_write};
 
 use super::{TableBase,TableBaseConst};
 
@@ -185,7 +183,7 @@ impl PreFetchable for PawnTable {
     fn prefetch(&self, key: u64) {
         unsafe {
             let ptr = self.table.get_ptr(key);
-            prefetch::<Write, High, Data, PawnEntry>(ptr);
+            prefetch_write(ptr);
         }
     }
 
@@ -193,9 +191,9 @@ impl PreFetchable for PawnTable {
     fn prefetch2(&self, key: u64) {
         unsafe {
             let ptr = self.table.get_ptr(key);
-            prefetch::<Write, High, Data, PawnEntry>(ptr);
+            prefetch_write(ptr);
             let ptr_2 = (ptr as *mut u8).offset(64) as *mut PawnEntry;
-            prefetch::<Write, High, Data, PawnEntry>(ptr_2);
+            prefetch_write(ptr_2);
         }
     }
 }


### PR DESCRIPTION
General Changes
- Update docs
- Update Travis to test `pleco` on stable rust.

`pleco` Changes
- Now compiles on stable!!
- Added `nightly` feature for advanced optimizations on nightly toolchain.
- Modified `move_list::MAX_MOVES` to adjust for cache size based on target pointer width.
- Removed `prefetch` dependency and added a new prefetch.
- Improved `PRNG::singular_bit()`'s randomness (Better distribution of bits).
- Allocation now depends on `Alloc`, not `GlobalAlloc`.

`pleco_engine` Changes
- Modified prefetch instructions to use `pleco::prefetch_write`
