### PR TITLE
Bit twiddling tweaks + MiniMax cleanup

### DIFF
--- a/pleco/benches/bit_benches.rs
+++ b/pleco/benches/bit_benches.rs
@@ -18,7 +18,7 @@ fn popcount_old_8(b: &mut Bencher, data: &Vec<BitBoard>) {
     b.iter(|| {
         black_box({
             for bits in data.iter() {
-                black_box({popcount_old(black_box((*bits).0));})
+                black_box({ popcount_table(black_box((*bits).0));})
             }
         })
     });

--- a/pleco/src/bots/minimax.rs
+++ b/pleco/src/bots/minimax.rs
@@ -7,21 +7,17 @@ pub fn minimax(board: &mut Board, depth: u16) -> ScoringMove {
         return eval_board(board);
     }
 
-    let moves = board.generate_scoring_moves();
-    if moves.is_empty() {
-        if board.in_check() {
-            return ScoringMove::blank(-MATE_V);
-        } else {
-            return ScoringMove::blank(DRAW_V);
-        }
-    }
-
-    moves.into_iter()
+    board.generate_scoring_moves()
+        .into_iter()
         .map(|mut m: ScoringMove| {
             board.apply_move(m.bit_move);
             m.score = -minimax(board, depth - 1).score;
             board.undo_move();
             m
-        }).max()
-        .unwrap()
+        })
+        .max()
+        .unwrap_or_else(|| match board.in_check() {
+            true => ScoringMove::blank(-MATE_V),
+            false => ScoringMove::blank(DRAW_V)
+        })
 }


### PR DESCRIPTION
`pleco` Changes
- popcount now uses a table lookup by default.
-`bit_scan_forward` now does an unchecked lookup on the De Bruijn table
- `minimax` cleanup.